### PR TITLE
Fix room controller level retrieval in creep role definitions to hand…

### DIFF
--- a/definitions_creep_roles.js
+++ b/definitions_creep_roles.js
@@ -102,7 +102,7 @@
 					return;
 
 				// Check if room has reached RCL 6+ and has upgraders
-				let roomLevel = creep.room.controller.level;
+				let roomLevel = creep.room.controller ? creep.room.controller.level : 0;
 				let hasUpgraders = _.filter(Game.creeps, c => 
 					c.memory.role == "upgrader" && c.memory.room == creep.room.name).length > 0;
 				let isCriticalDowngrade = _.get(Memory, ["rooms", creep.room.name, "survey", "downgrade_critical"], false);


### PR DESCRIPTION
This pull request includes a small but important fix to the `definitions_creep_roles.js` file. The change ensures that the `roomLevel` variable is safely assigned even if the `controller` property is undefined.

* [`definitions_creep_roles.js`](diffhunk://#diff-90f1e4c3386414cae6885f3272a5f72bd9ba9f46bce74a0a5a4194536dace373L105-R105): Updated the `roomLevel` assignment to use a conditional check (`creep.room.controller ? creep.room.controller.level : 0`) to avoid errors when the `controller` property is missing.…le cases where the controller may not be present, ensuring robust functionality in various room states.