### PR TITLE
fix: remove deprecated HTML console formatting tags

### DIFF
--- a/definitions_blueprint.js
+++ b/definitions_blueprint.js
@@ -7,15 +7,28 @@
 	Init: function () {
 		// Process special blueprint requests (from console) immediately, effectively pausing cycles/pulses by 1 tick.
 		if (_.get(Memory, ["hive", "pulses", "blueprint", "request"]) != null) {
-			let room = Game.rooms[_.get(Memory, ["hive", "pulses", "blueprint", "request"])];
+			let requestedRoom = _.get(Memory, ["hive", "pulses", "blueprint", "request"]);
+			let room = Game.rooms[requestedRoom];
 
+			// If room is not in our shard, don't process (avoid ERR_NO_PATH logs)
 			if (room == null) {
-				console.log(`<font color=\"#6065FF\">[Blueprint]</font> Blueprint() request for ${_.get(Memory, ["hive", "pulses", "blueprint", "request"])} failed; unable to find in Game.rooms.`);
+				// Check if this is a room on another shard - if so, don't log an error, just ignore
+				let isRemoteRoom = false;
+				if (requestedRoom && requestedRoom.includes("/")) {
+					isRemoteRoom = true; // Cross-shard room reference like "shard1/E50S20"
+				}
+				
+				if (!isRemoteRoom) {
+					console.log(`<font color="#6065FF">[Blueprint]</font> Blueprint() request for ${requestedRoom} failed; unable to find in Game.rooms.`);
+				}
 			} else {
-				Stats_CPU.Start("Hive", "Blueprint-Run");
-				console.log(`<font color=\"#6065FF\">[Blueprint]</font> Processing requested Blueprint() for ${room.name}`);
-				this.Run(room);
-				Stats_CPU.End("Hive", "Blueprint-Run");
+				// Only process if the room is owned by us
+				if (room.controller && room.controller.my) {
+					Stats_CPU.Start("Hive", "Blueprint-Run");
+					console.log(`<font color="#6065FF">[Blueprint]</font> Processing requested Blueprint() for ${room.name}`);
+					this.Run(room);
+					Stats_CPU.End("Hive", "Blueprint-Run");
+				}
 			}
 
 			delete Memory["hive"]["pulses"]["blueprint"]["request"];

--- a/definitions_blueprint.js
+++ b/definitions_blueprint.js
@@ -19,13 +19,13 @@
 				}
 				
 				if (!isRemoteRoom) {
-					console.log(`<font color="#6065FF">[Blueprint]</font> Blueprint() request for ${requestedRoom} failed; unable to find in Game.rooms.`);
+					console.log(`[Blueprint] Blueprint() request for ${requestedRoom} failed; unable to find in Game.rooms.`);
 				}
 			} else {
 				// Only process if the room is owned by us
 				if (room.controller && room.controller.my) {
 					Stats_CPU.Start("Hive", "Blueprint-Run");
-					console.log(`<font color="#6065FF">[Blueprint]</font> Processing requested Blueprint() for ${room.name}`);
+					console.log(`[Blueprint] Processing requested Blueprint() for ${room.name}`);
 					this.Run(room);
 					Stats_CPU.End("Hive", "Blueprint-Run");
 				}
@@ -52,7 +52,7 @@
 		Stats_CPU.Start("Hive", "Blueprint-Run");
 		let room = (room_iter < room_list.length ? Game.rooms[room_list[room_iter]] : null);
 		if (room != null) {
-			console.log(`<font color=\"#6065FF\">[Blueprint]</font> ${room_iter + 1}/${room_list.length}: Running Blueprint() for ${room.name}`);
+			console.log(`[Blueprint] ${room_iter + 1}/${room_list.length}: Running Blueprint() for ${room.name}`);
 			this.Run(room);			// Run blueprinting for this room
 		}
 
@@ -130,7 +130,7 @@
 			}).length == 0) {
 				Memory["rooms"][room.name]["layout"]["blocked_areas"].push(
 					{ start: { x: (s.pos.x - 1), y: (s.pos.y - 1) }, end: { x: (s.pos.x + 1), y: (s.pos.y + 1) } });
-				console.log(`<font color=\"#6065FF\">[Blueprint]</font> Blocking area in ${room.name} for source around (${s.pos.x}, ${s.pos.y}).`);
+				console.log(`[Blueprint] Blocking area in ${room.name} for source around (${s.pos.x}, ${s.pos.y}).`);
 			}
 		});
 
@@ -140,7 +140,7 @@
 		}).length == 0) {
 			Memory["rooms"][room.name]["layout"]["blocked_areas"].push(
 				{ start: { x: (mineral.pos.x - 1), y: (mineral.pos.y - 1) }, end: { x: (mineral.pos.x + 1), y: (mineral.pos.y + 1) } });
-			console.log(`<font color=\"#6065FF\">[Blueprint]</font> Blocking area in ${room.name} for mineral around (${mineral.pos.x}, ${mineral.pos.y}).`);
+			console.log(`[Blueprint] Blocking area in ${room.name} for mineral around (${mineral.pos.x}, ${mineral.pos.y}).`);
 		}
 
 		if (_.filter(blocked_areas, a => {
@@ -149,7 +149,7 @@
 		}).length == 0) {
 			Memory["rooms"][room.name]["layout"]["blocked_areas"].push(
 				{ start: { x: (room.controller.pos.x - 1), y: (room.controller.pos.y - 1) }, end: { x: (room.controller.pos.x + 1), y: (room.controller.pos.y + 1) } });
-			console.log(`<font color=\"#6065FF\">[Blueprint]</font> Blocking area in ${room.name} for room controller around (${room.controller.pos.x}, ${room.controller.pos.y}).`);
+			console.log(`[Blueprint] Blocking area in ${room.name} for room controller around (${room.controller.pos.x}, ${room.controller.pos.y}).`);
 		}
 
 		// If colonization focused on rapidly building defenses (RCL 3), don't place anything until tower is built
@@ -188,7 +188,7 @@
 					if (sites < sites_per_room && source.pos.findInRange(containers, 1).length < 2) {
 						let adj = source.pos.getBuildableTile_Adjacent();
 						if (adj != null && adj.createConstructionSite("container") == OK) {
-							console.log(`<font color=\"#6065FF\">[Blueprint]</font> ${room.name} placing container at (${adj.x}, ${adj.y})`);
+							console.log(`[Blueprint] ${room.name} placing container at (${adj.x}, ${adj.y})`);
 							sites += 1;
 						}
 					}
@@ -208,7 +208,7 @@
 					if (sites < sites_per_room && source.pos.findInRange(containers, 1).length < 2) {
 						let adj = source.pos.getBuildableTile_Adjacent();
 						if (adj != null && adj.createConstructionSite("container") == OK) {
-							console.log(`<font color=\"#6065FF\">[Blueprint]</font> ${room.name} placing container at (${adj.x}, ${adj.y})`);
+							console.log(`[Blueprint] ${room.name} placing container at (${adj.x}, ${adj.y})`);
 							sites += 1;
 						}
 					}
@@ -261,7 +261,7 @@
 					if (sites < sites_per_room && source.pos.findInRange(links, 2).length == 0) {
 						let adj = source.pos.getOpenTile_Path(2);
 						if (adj != null && adj.createConstructionSite("link") == OK) {
-							console.log(`<font color=\"#6065FF\">[Blueprint]</font> ${room.name} placing link at (${adj.x}, ${adj.y})`);
+							console.log(`[Blueprint] ${room.name} placing link at (${adj.x}, ${adj.y})`);
 							sites += 1;
 						}
 					}
@@ -279,7 +279,7 @@
 				if (sites < sites_per_room && room.controller.pos.findInRange(links, 2).length < cont_links) {
 					let adj = room.controller.pos.getOpenTile_Path(2);
 					if (adj != null && adj.createConstructionSite("link") == OK) {
-						console.log(`<font color=\"#6065FF\">[Blueprint]</font> ${room.name} placing link at (${adj.x}, ${adj.y})`);
+						console.log(`[Blueprint] ${room.name} placing link at (${adj.x}, ${adj.y})`);
 						sites += 1;
 					}
 				}
@@ -294,7 +294,7 @@
 				let extractors = _.filter(structures, s => { return s.structureType == "extractor"; }).length;
 				if (extractors < CONTROLLER_STRUCTURES["extractor"][level]) {
 					if (room.createConstructionSite(mineral.pos.x, mineral.pos.y, "extractor") == OK) {
-						console.log(`<font color=\"#6065FF\">[Blueprint]</font> ${room.name} placing extractor at `
+						console.log(`[Blueprint] ${room.name} placing extractor at `
 							+ `(${mineral.pos.x}, ${mineral.pos.y})`);
 						sites += 1;
 					}
@@ -310,7 +310,7 @@
 						|| structure.structureType == "storage" || structure.structureType == "terminal"
 						|| structure.structureType == "nuker" || structure.structureType == "powerSpawn") {
 						if (room.createConstructionSite(structure.pos.x, structure.pos.y, "rampart") == OK) {
-							console.log(`<font color=\"#6065FF\">[Blueprint]</font> ${room.name} placing rampart over `
+							console.log(`[Blueprint] ${room.name} placing rampart over `
 								+ `${structure.structureType} at (${structure.pos.x}, ${structure.pos.y})`);
 							sites += 1;
 						}
@@ -374,7 +374,7 @@
 
 			let result = room.createConstructionSite(x, y, structureType);
 			if (result == OK) {
-				console.log(`<font color=\"#6065FF\">[Blueprint]</font> ${room.name} placing ${structureType} at `
+				console.log(`[Blueprint] ${room.name} placing ${structureType} at `
 					+ `(${origin.x + layout[structureType][i].x}, ${origin.y + layout[structureType][i].y})`);
 				sites += 1;
 			} else if (result == ERR_INVALID_TARGET) {
@@ -414,7 +414,7 @@
 		}
 
 		if (road > 0) {
-			console.log(`<font color=\"#6065FF\">[Blueprint]</font> ${room.name} placed ${road} construction sites for a road `
+			console.log(`[Blueprint] ${room.name} placed ${road} construction sites for a road `
 				+ `from (${from_pos.x}, ${from_pos.y}) to (${to_pos.x}, ${to_pos.y})`);
 			sites += road;
 		}

--- a/definitions_console_commands.js
+++ b/definitions_console_commands.js
@@ -55,14 +55,14 @@
 		allies.add = function (ally) {
 			if (_.get(Memory, ["hive", "allies"]) == null) _.set(Memory["hive", "allies"], []);
 			Memory["hive"]["allies"].push(ally);
-			return `<font color=\"#D3FFA3\">[Console]</font> Player ${ally} added to ally list.`
+			return `[Console] Player ${ally} added to ally list.`
 		};
 
 		help_allies.push("allies.add_list([ally1, ally2, ...])");
 
 		allies.add_list = function (allyList) {
 			Array.prototype.push.apply(Memory["hive"]["allies"], allyList);
-			return `<font color=\"#D3FFA3\">[Console]</font> Players added to ally list.`
+			return `[Console] Players added to ally list.`
 		};
 
 		help_allies.push("allies.remove(ally)");
@@ -71,16 +71,16 @@
 			let index = _.get(Memory, ["hive", "allies"]).indexOf(ally);
 			if (index >= 0) {
 				Memory["hive"]["allies"].splice(index, 1);
-				return `<font color=\"#D3FFA3\">[Console]</font> Player ${ally} removed from ally list.`
+				return `[Console] Player ${ally} removed from ally list.`
 			} else {
-				return `<font color=\"#D3FFA3\">[Console]</font> Error: Player ${ally} not found in ally list.`
+				return `[Console] Error: Player ${ally} not found in ally list.`
 			}
 		};
 
 		help_allies.push("allies.clear()");
 		allies.clear = function () {
 			_.set(Memory, ["hive", "allies"], []);
-			return `<font color=\"#D3FFA3\">[Console]</font> Ally list cleared.`
+			return `[Console] Ally list cleared.`
 		};
 
 
@@ -89,7 +89,7 @@
 
 		blueprint.set_layout = function (rmName, originX, originY, layoutName) {
 			_.set(Memory, ["rooms", rmName, "layout"], { origin: { x: originX, y: originY }, name: layoutName });
-			return `<font color=\"#D3FFA3\">[Console]</font> Blueprint layout set for ${rmName}.`;
+			return `[Console] Blueprint layout set for ${rmName}.`;
 		};
 
 		help_blueprint.push("blueprint.block(rmName, x, y)");
@@ -98,7 +98,7 @@
 			if (_.get(Memory, ["rooms", rmName, "layout", "blocked_areas"]) == null)
 				Memory["rooms"][rmName]["layout"]["blocked_areas"] = [];
 			Memory["rooms"][rmName]["layout"]["blocked_areas"].push({ start: { x: x, y: y }, end: { x: x, y: y } });
-			return `<font color=\"#D3FFA3\">[Console]</font> Blueprint position blocked for ${rmName} at (${x}, ${y}).`;
+			return `[Console] Blueprint position blocked for ${rmName} at (${x}, ${y}).`;
 		};
 
 		help_blueprint.push("blueprint.block_area(rmName, startX, startY, endX, endY)");
@@ -112,21 +112,21 @@
 			if (_.get(Memory, ["rooms", rmName, "layout", "blocked_areas"]) == null)
 				Memory["rooms"][rmName]["layout"]["blocked_areas"] = [];
 			Memory["rooms"][rmName]["layout"]["blocked_areas"].push({ start: { x: startX, y: startY }, end: { x: endX, y: endY } });
-			return `<font color=\"#D3FFA3\">[Console]</font> Blueprint area blocked for ${rmName} from (${startX}, ${startY}) to (${endX}, ${endY}).`;
+			return `[Console] Blueprint area blocked for ${rmName} from (${startX}, ${startY}) to (${endX}, ${endY}).`;
 		};
 
 		help_blueprint.push("blueprint.request(rmName)");
 
 		blueprint.request = function (rmName) {
 			_.set(Memory, ["hive", "pulses", "blueprint", "request"], rmName);
-			return `<font color=\"#D3FFA3\">[Console]</font> Setting Blueprint() request for ${rmName}; Blueprint() will run this request next tick.`;
+			return `[Console] Setting Blueprint() request for ${rmName}; Blueprint() will run this request next tick.`;
 		};
 
 	help_blueprint.push("blueprint.reset()");
 	blueprint.reset = function () {
 		if (_.get(Memory, ["shard", "pulses", "blueprint"], null) != null)
 			delete Memory.shard.pulses.blueprint;				
-		return `<font color=\"#D3FFA3\">[Console]</font> Resetting Blueprint() cycles; Blueprint() will initiate next tick.`;
+		return `[Console] Resetting Blueprint() cycles; Blueprint() will initiate next tick.`;
 	};
 
 		help_blueprint.push("blueprint.redefine_links()");
@@ -137,7 +137,7 @@
 			});
 
 			_.set(Memory, ["hive", "pulses", "reset_links"], true);
-			return `<font color=\"#D3FFA3\">[Console]</font> Resetting all link definitions; will redefine next tick.`;
+			return `[Console] Resetting all link definitions; will redefine next tick.`;
 		};
 
 		help_blueprint.push("blueprint.toggle_walls(rmName)");
@@ -149,7 +149,7 @@
 			else
 				_.set(Memory, ["rooms", rmName, "layout", "place_defenses"], true)
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Blueprint placing defensive walls and ramparts: ${_.get(Memory, ["rooms", rmName, "layout", "place_defenses"], true)}`;
+			return `[Console] Blueprint placing defensive walls and ramparts: ${_.get(Memory, ["rooms", rmName, "layout", "place_defenses"], true)}`;
 		};
 
 		help_blueprint.push("blueprint.diagnose(roomName)");
@@ -157,7 +157,7 @@
 		blueprint.diagnose = function (roomName) {
 			let room = Game.rooms[roomName];
 			if (!room || !room.controller || !room.controller.my) {
-				return `<font color=\"#FF6B6B\">[Console]</font> Room ${roomName} not found or not owned.`;
+				return `[Console] Room ${roomName} not found or not owned.`;
 			}
 
 			let hasLayout = _.get(Memory, ["rooms", roomName, "layout"]) != null;
@@ -171,7 +171,7 @@
 			let sitesPerRoom = room.controller.level <= 4 ? 15 : 10;
 
 			let output = [];
-			output.push(`<font color=\"#D3FFA3\">[Blueprint]</font> Diagnostics for ${roomName}:`);
+			output.push(`[Blueprint] Diagnostics for ${roomName}:`);
 			output.push(`  Controller Level: ${room.controller.level}`);
 			output.push(`  Has Layout: ${hasLayout}`);
 			output.push(`  Has Origin: ${hasOrigin}`);
@@ -195,7 +195,7 @@
 			}
 
 			if (!hasOrigin) {
-				output.push(`<font color=\"#FF6B6B\">[Blueprint]</font> ISSUE: No layout origin set!`);
+				output.push(`[Blueprint] ISSUE: No layout origin set!`);
 				if (hasColonizationSite && colonizationLayout) {
 					output.push(`  Solution: Run blueprint.recover_layout("${roomName}") to recover from colonization site`);
 				} else if (spawns.length > 0) {
@@ -218,19 +218,19 @@
 		blueprint.recover_layout = function (roomName) {
 			let room = Game.rooms[roomName];
 			if (!room || !room.controller || !room.controller.my) {
-				return `<font color=\"#FF6B6B\">[Console]</font> Room ${roomName} not found or not owned.`;
+				return `[Console] Room ${roomName} not found or not owned.`;
 			}
 
 			let colonizationSite = _.get(Memory, ["sites", "colonization", roomName]);
 			if (!colonizationSite || !colonizationSite.layout) {
-				return `<font color=\"#FF6B6B\">[Console]</font> No colonization site found for ${roomName} with layout data.`;
+				return `[Console] No colonization site found for ${roomName} with layout data.`;
 			}
 
 			let layout = colonizationSite.layout;
 			_.set(Memory, ["rooms", roomName, "layout"], layout);
 			_.set(Memory, ["hive", "pulses", "blueprint", "request"], roomName);
 			
-			return `<font color=\"#D3FFA3\">[Console]</font> Recovered layout for ${roomName}: ${layout.name} at (${layout.origin.x}, ${layout.origin.y}). Blueprint requested for next tick.`;
+			return `[Console] Recovered layout for ${roomName}: ${layout.name} at (${layout.origin.x}, ${layout.origin.y}). Blueprint requested for next tick.`;
 		};
 
 
@@ -250,7 +250,7 @@
 				amount: amount, 
 				priority: priority || 50 
 			});
-			return `<font color=\"#D3FFA3\">[Console]</font> ${commodity} production target set to ${amount} (priority ${priority || 50}).`;
+			return `[Console] ${commodity} production target set to ${amount} (priority ${priority || 50}).`;
 		};
 
 		help_factories.push("factories.clear_production(commodity)");
@@ -261,9 +261,9 @@
 		factories.clear_production = function (commodity) {
 			if (_.get(Memory, ["resources", "factories", "targets", commodity]) != null) {
 				delete Memory["resources"]["factories"]["targets"][commodity];
-				return `<font color=\"#D3FFA3\">[Console]</font> ${commodity} production target cleared.`;
+				return `[Console] ${commodity} production target cleared.`;
 			}
-			return `<font color=\"#D3FFA3\">[Console]</font> No production target found for ${commodity}.`;
+			return `[Console] No production target found for ${commodity}.`;
 		};
 
 		help_factories.push("factories.clear_all()");
@@ -272,7 +272,7 @@
 
 		factories.clear_all = function () {
 			_.set(Memory, ["resources", "factories", "targets"], new Object());
-			return `<font color=\"#D3FFA3\">[Console]</font> All factory production targets cleared.`;
+			return `[Console] All factory production targets cleared.`;
 		};
 
 		help_factories.push("factories.status()");
@@ -297,11 +297,11 @@
 			let headerStyle = "style=\"border: 1px solid #666; padding: 8px 12px; text-align: left; background-color: #444; color: #D3FFA3; font-weight: bold;\"";
 			
 			// Production Targets Table
-			console.log(`<font color=\"#FFA500\">[Factory]</font> <b>Factory Production Targets:</b>`);
+			console.log(`[Factory] Factory Production Targets:`);
 			if (targets == null || Object.keys(targets).length == 0) {
-				console.log(`<font color=\"#FFA500\">[Factory]</font> No production targets set.`);
+				console.log(`[Factory] No production targets set.`);
 			} else {
-				let targetTable = `<table ${tableStyle}><tr><th ${headerStyle}>Commodity</th><th ${headerStyle}>Current</th><th ${headerStyle}>Target</th><th ${headerStyle}>Progress</th><th ${headerStyle}>Priority</th></tr>`;
+				let targetTable = `	Commodity		Current		Target		Progress		Priority	`;
 				_.each(targets, (target, commodity) => {
 					let current = 0;
 					_.each(_.filter(Game.rooms, r => { return r.controller != null && r.controller.my; }), room => {
@@ -318,15 +318,15 @@
 					});
 					let progress = Math.min(100, Math.round((current / target.amount) * 100));
 					let progressBar = "|".repeat(Math.floor(progress/10)) + "-".repeat(10 - Math.floor(progress/10));
-					targetTable += `<tr><td ${cellStyle}>${commodity}</td><td ${cellStyle}>${current}</td><td ${cellStyle}>${target.amount}</td><td ${cellStyle}>${progressBar} ${progress}%</td><td ${cellStyle}>${target.priority}</td></tr>`;
+					targetTable += `	${commodity}		${current}		${target.amount}		${progressBar} ${progress}%		${target.priority}	`;
 				});
-				targetTable += "</table>";
+				targetTable += "";
 				console.log(targetTable);
 			}
 
 			// Factory Assignments and Status Table
-			console.log(`<font color=\"#FFA500\">[Factory]</font> <b>Factory Status:</b>`);
-			let factoryTable = `<table ${tableStyle}><tr><th ${headerStyle}>Room</th><th ${headerStyle}>Assignment</th><th ${headerStyle}>Cooldown</th><th ${headerStyle}>Store</th><th ${headerStyle}>Status</th></tr>`;
+			console.log(`[Factory] Factory Status:`);
+			let factoryTable = `	Room		Assignment		Cooldown		Store		Status	`;
 			let totalFactories = 0;
 			let assignedFactories = 0;
 			let activeFactories = 0;
@@ -364,15 +364,15 @@
 							}
 						}
 						
-						factoryTable += `<tr><td ${cellStyle}><font color=\"#D3FFA3\">${room.name}</font></td><td ${cellStyle}>${assignmentText}</td><td ${cellStyle}>${cooldownText}</td><td ${cellStyle}>${storeText}</td><td ${cellStyle}>${status}</td></tr>`;
+						factoryTable += `	${room.name}		${assignmentText}		${cooldownText}		${storeText}		${status}	`;
 					});
 				}
 			});
-			factoryTable += "</table>";
+			factoryTable += "";
 			console.log(factoryTable);
 
 			// Summary
-			console.log(`<font color=\"#FFA500\">[Factory]</font> <b>Summary:</b> ${totalFactories} total factories, ${assignedFactories} assigned, ${activeFactories} active`);
+			console.log(`[Factory] Summary: ${totalFactories} total factories, ${assignedFactories} assigned, ${activeFactories} active`);
 
 			// Industry Tasks Summary (condensed)
 			let totalTasks = 0;
@@ -393,20 +393,20 @@
 			});
 			
 			if (totalTasks > 0) {
-				console.log(`<font color=\"#FFA500\">[Factory]</font> <b>Industry Tasks:</b> ${totalTasks} total (P2: ${priority2Tasks}, P3: ${priority3Tasks}, P5: ${priority5Tasks})`);
+				console.log(`[Factory] Industry Tasks: ${totalTasks} total (P2: ${priority2Tasks}, P3: ${priority3Tasks}, P5: ${priority5Tasks})`);
 			}
 
 			// CPU Usage Information
 			let cpuUsed = Game.cpu.getUsed();
 			let cpuBucket = Game.cpu.bucket;
-			console.log(`<font color=\"#FFA500\">[Factory]</font> <b>CPU Status:</b> Used: ${cpuUsed.toFixed(2)}, Bucket: ${cpuBucket.toFixed(0)}`);
+			console.log(`[Factory] CPU Status: Used: ${cpuUsed.toFixed(2)}, Bucket: ${cpuBucket.toFixed(0)}`);
 
-			return `<font color=\"#FFA500\">[Factory]</font> Factory status displayed.`;
+			return `[Factory] Factory status displayed.`;
 		};
 
 		factories.renew_assignments = function (announce = true) {
 			if (announce) {
-				console.log(`<font color=\"#FFA500\">[Factory]</font> Renewing factory assignments...`);
+				console.log(`[Factory] Renewing factory assignments...`);
 			}
 			// Safely clear existing assignments to force fresh assignment
 			if (Memory["resources"] && Memory["resources"]["factories"]) {
@@ -416,15 +416,15 @@
 			if (Memory["hive"] && Memory["hive"]["pulses"]) {
 				delete Memory["hive"]["pulses"]["factory"];
 			}
-			return `<font color=\"#FFA500\">[Factory]</font> Factory assignments will be renewed next tick based on current priorities.`;
+			return `[Factory] Factory assignments will be renewed next tick based on current priorities.`;
 		};
 
 		factories.clear_assignments = function () {
 			if (Memory["resources"] && Memory["resources"]["factories"]) {
 				delete Memory["resources"]["factories"]["assignments"];
-				return `<font color=\"#FFA500\">[Factory]</font> Factory assignments cleared.`;
+				return `[Factory] Factory assignments cleared.`;
 			} else {
-				return `<font color=\"#FFA500\">[Factory]</font> No factory assignments to clear.`;
+				return `[Factory] No factory assignments to clear.`;
 			}
 		};
 
@@ -446,7 +446,7 @@
 			// Check if it's time for cleanup
 			if (currentTick - Memory.factories.lastCleanup >= Memory.factories.cleanupInterval) {
 				if (announce) {
-					console.log(`<font color=\"#FFA500\">[Factory]</font> Running scheduled factory cleanup...`);
+					console.log(`[Factory] Running scheduled factory cleanup...`);
 				}
 				this.cleanup(1, announce); // High priority cleanup
 				Memory.factories.lastCleanup = currentTick;
@@ -456,7 +456,7 @@
 			// Check if it's time for assignment renewal
 			if (currentTick - Memory.factories.lastAssignmentCheck >= Memory.factories.assignmentCheckInterval) {
 				if (announce) {
-					console.log(`<font color=\"#FFA500\">[Factory]</font> Running scheduled assignment check...`);
+					console.log(`[Factory] Running scheduled assignment check...`);
 				}
 				this.renew_assignments(announce);
 				Memory.factories.lastAssignmentCheck = currentTick;
@@ -464,9 +464,9 @@
 			}
 			
 			if (maintenanceActions.length > 0) {
-				return `<font color=\"#FFA500\">[Factory]</font> Factory maintenance completed: ${maintenanceActions.join(', ')}`;
+				return `[Factory] Factory maintenance completed: ${maintenanceActions.join(', ')}`;
 			} else {
-				return `<font color=\"#FFA500\">[Factory]</font> No maintenance actions needed at tick ${currentTick}`;
+				return `[Factory] No maintenance actions needed at tick ${currentTick}`;
 			}
 		};
 
@@ -638,26 +638,26 @@
 				let cellStyle = "style=\"border: 1px solid #666; padding: 6px 8px; text-align: left; font-size: 12px;\"";
 				let headerStyle = "style=\"border: 1px solid #666; padding: 8px 12px; text-align: left; background-color: #FFA500; color: white; font-weight: bold;\"";
 				
-				let cleanupTable = `<table ${tableStyle}>`;
-				cleanupTable += `<tr><th ${headerStyle}>Room</th><th ${headerStyle}>Status</th><th ${headerStyle}>Details</th></tr>`;
-				cleanupTable += `<tr><td ${cellStyle}>${cleanupData[0].room}</td><td ${cellStyle}><font color=\"${cleanupData[0].status.includes("✓") ? "green" : "red"}\">${cleanupData[0].status}</font></td><td ${cellStyle}>${cleanupData[0].details}</td></tr>`;
+				let cleanupTable = ``;
+				cleanupTable += `	Room		Status		Details	`;
+				cleanupTable += `	${cleanupData[0].room}		${cleanupData[0].status}		${cleanupData[0].details}	`;
 				
 				// Add factory details if available
 				if (cleanupData[0].factories && cleanupData[0].factories.length > 0) {
 					_.each(cleanupData[0].factories, factory => {
-						cleanupTable += `<tr><td ${cellStyle} style=\"padding-left: 20px;\">└─ ${factory.factory}</td><td ${cellStyle}>${factory.assignment}</td><td ${cellStyle}>${factory.actions}</td></tr>`;
+						cleanupTable += `	└─ ${factory.factory}		${factory.assignment}		${factory.actions}	`;
 					});
 				}
 				
-				cleanupTable += "</table>";
-				console.log(`<font color=\"#FFA500\">[Factory]</font> <b>Cleanup Summary (Priority ${priority}):</b><br>${cleanupTable}`);
+				cleanupTable += "";
+				console.log(`[Factory] Cleanup Summary (Priority ${priority}):\n${cleanupTable}`);
 			}
 			
 			if (roomsProcessed === 0) {
-				return `<font color=\"#FFA500\">[Factory]</font> No rooms with factories found.`;
+				return `[Factory] No rooms with factories found.`;
 			}
 			
-			return `<font color=\"#FFA500\">[Factory]</font> Factory cleanup completed. Created ${totalCleanupTasks} cleanup tasks across ${roomsProcessed} rooms.`;
+			return `[Factory] Factory cleanup completed. Created ${totalCleanupTasks} cleanup tasks across ${roomsProcessed} rooms.`;
 		};
 
 
@@ -676,14 +676,14 @@
 			this.labs();
 			this.controllers();
 			this.resources();
-			return `<font color=\"#D3FFA3\">[Console]</font> Main logs printed.`;
+			return `[Console] Main logs printed.`;
 		}
 
 		help_log.push("log.can_build()");
 
 		log.can_build = function () {
 			let rooms = _.filter(Game.rooms, n => { return n.controller != null && n.controller.my; });
-			console.log("<font color=\"#D3FFA3\">[Console]</font> Buildable structures:");
+			console.log("[Console] Buildable structures:");
 			for (let r in rooms) {
 				room = rooms[r];
 
@@ -698,62 +698,62 @@
 				}
 				console.log(output);
 			}
-			return "<font color=\"#D3FFA3\">[Console]</font> Report generated";
+			return "[Console] Report generated";
 		};
 
 		help_log.push("log.controllers()");
 
 		log.controllers = function () {
-			console.log("<font color=\"#D3FFA3\">[Console]</font> Room Controllers:");
-			let output = "<table>";
+			console.log("[Console] Room Controllers:");
+			let output = "";
 			_.each(_.sortBy(_.sortBy(_.filter(Game.rooms,
 				r => { return r.controller != null && r.controller.my; }),
 				r => { return -r.controller.progress; }),
 				r => { return -r.controller.level; }), r => {
-					output += `<tr><td><font color=\"#D3FFA3\">${r.name}:</font>  (${r.controller.level})  </td> `
-						+ `<td>${r.controller.progress}  </td><td>  /  </td><td>${r.controller.progressTotal}    </td> `
-						+ `<td>(${(r.controller.progress / r.controller.progressTotal * 100).toFixed()} %)</td></tr>`;
+					output += `	${r.name}:  (${r.controller.level})  	 `
+						+ `	${r.controller.progress}  		  /  		${r.controller.progressTotal}    	 `
+						+ `	(${(r.controller.progress / r.controller.progressTotal * 100).toFixed()} %)	`;
 				});
-			console.log(`${output}</table>`);
-			return "<font color=\"#D3FFA3\">[Console]</font> Report generated";
+			console.log(`${output}`);
+			return "[Console] Report generated";
 		};
 
 		help_log.push("log.populations()");
 
 		log.populations = function () {
-			console.log("<font color=\"#D3FFA3\">[Console]</font> Populations for Colonies and Mining Sites (default and set_population):");
+			console.log("[Console] Populations for Colonies and Mining Sites (default and set_population):");
 
 			let colonies = _.keys(_.filter(Game.rooms, room => { return (room.controller != null && room.controller.my); }));
 			let mining = _.keys(_.get(Memory, ["sites", "mining"]));
 			let rooms = _.keys(_.get(Memory, "rooms"));
-			let output = "<table>";
+			let output = "";
 
 			for (let i = 0; i < rooms.length; i++) {
 				if (_.indexOf(colonies, rooms[i]) >= 0 || _.indexOf(mining, rooms[i]) >= 0) {
 					if (_.has(Memory, ["rooms", rooms[i], "set_population"])) {
-						output += `<tr><td><font color=\"#D3FFA3\">${(rooms[i])}</font>: \t</td>`;
+						output += `	${(rooms[i])}: \t	`;
 						let populations = _.keys(Memory["rooms"][rooms[i]]["set_population"]);
 						for (let j = 0; j < populations.length; j++) {
-							output += `<td>${populations[j]}: </td> `
-							+ `<td>lvl ${_.get(Memory, ["rooms", rooms[i], "set_population", populations[j], "level"])}</td>`
-							+ `<td> x ${_.get(Memory, ["rooms", rooms[i], "set_population", populations[j], "amount"])} \t</td>  `;
+							output += `	${populations[j]}: 	 `
+							+ `	lvl ${_.get(Memory, ["rooms", rooms[i], "set_population", populations[j], "level"])}	`
+							+ `	 x ${_.get(Memory, ["rooms", rooms[i], "set_population", populations[j], "amount"])} \t	  `;
 						}
-						output += `</tr>`;
+						output += ``;
 					} else {
-						output += `<tr><td><font color=\"#D3FFA3\">${(rooms[i])}</font>: \t</td>`
-							+`<td>default</td></tr>`;
+						output += `	${(rooms[i])}: \t	`
+							+`	default	`;
 					}
 				}
 			}
-			console.log(`${output}</table>`);
-			return "<font color=\"#D3FFA3\">[Console]</font> Report generated";
+			console.log(`${output}`);
+			return "[Console] Report generated";
 		}
 
 		help_log.push("log.labs()");
 
 		log.labs = function () {
-			let output = "<font color=\"#D3FFA3\">[Console]</font> Lab Report<br>"
-				+ "<table><tr><th>Room \t</th><th>Mineral \t</th><th>Amount \t</th><th>Target Amount \t</th><th>Reagent #1 \t</th><th>Reagent #2</th></tr>";
+			let output = "[Console] Lab Report\n"
+				+ "	Room \t		Mineral \t		Amount \t		Target Amount \t		Reagent #1 \t		Reagent #2	";
 
 			_.each(_.keys(_.get(Memory, ["resources", "labs", "reactions"])), r => {
 				let rxn = Memory["resources"]["labs"]["reactions"][r];
@@ -771,14 +771,14 @@
 						_.each(_.filter(Game.rooms,
 							r => { return r.controller != null && r.controller.my && (r.storage || r.terminal); }),
 							r => { r_amount += r.store(reagent); });
-						reagents += `<td>${reagent}: \t${r_amount}</td>`;
+						reagents += `	${reagent}: \t${r_amount}	`;
 					});
 
-				output += `<tr><td>${r}</td><td>${_.get(rxn, "mineral")}</td><td>${amount}</td><td>(${_.get(rxn, "amount")})${reagents}</tr>`
+				output += `	${r}		${_.get(rxn, "mineral")}		${amount}		(${_.get(rxn, "amount")})${reagents}`
 			});
 
-			console.log(`${output}</table>`);
-			return "<font color=\"#D3FFA3\">[Console]</font> Report generated";
+			console.log(`${output}`);
+			return "[Console] Report generated";
 		};
 
 		help_log.push("log.resources()");
@@ -787,8 +787,8 @@
 			let resource_list = resource != null ? [resource] : RESOURCES_ALL;
 			let room_list = _.filter(Game.rooms, r => { return r.controller != null && r.controller.my && (r.storage || r.terminal); });
 
-			let output = `<font color=\"#FFF"><tr><th>Resource\t</th><th>Total \t\t</th>`;
-			_.each(room_list, r => { output += `<th><font color=\"#${r.terminal ? "5DB65B" : "B65B5B"}\">${r.name}</font> \t</th>`; });
+			let output = `	Resource\t		Total \t\t	`;
+			_.each(room_list, r => { output += `	${r.terminal ? "[T]" : "[--]"} ${r.name} \t	`; });
 
 			_.each(resource_list, res => {
 				let amount = 0;
@@ -797,15 +797,15 @@
 				_.each(room_list, r => {
 					let a = r.store(res);
 					amount += a;
-					output_rooms += `<td>${a}</td>`
+					output_rooms += `	${a}	`
 				});
 
 				if (amount >= limit)
-					output += `<tr><td>${res}</td><td>${amount}</td> ${output_rooms} </tr>`;
+					output += `	${res}		${amount}	 ${output_rooms} `;
 			});
 
-			console.log(`<font color=\"#D3FFA3">log.resources</font> <table>${output}</table>`);
-			return "<font color=\"#D3FFA3\">[Console]</font> Report generated";
+			console.log(`log.resources ${output}`);
+			return "[Console] Report generated";
 		};
 
 		help_log.push("log.remote_mining()");
@@ -815,42 +815,42 @@
 			let remote = _.get(Memory, ["sites", "mining"]);
 
 			_.each(_.filter(Game.rooms, r => { return r.controller != null && r.controller.my; }), r => {
-				output += `<tr><td>${r.name}</td><td>  ->  </td>`;
-				_.each(_.filter(Object.keys(remote), rem => { return rem != r.name && _.get(remote[rem], "colony") == r.name; }), rem => { output += `<td>  ${rem}  </td>`; });
-				output += `</tr>`;
+				output += `	${r.name}		  ->  	`;
+				_.each(_.filter(Object.keys(remote), rem => { return rem != r.name && _.get(remote[rem], "colony") == r.name; }), rem => { output += `	  ${rem}  	`; });
+				output += ``;
 			});
 
-			console.log(`<font color=\"#D3FFA3">log.mining</font><table>${output}</table>`);
-			return "<font color=\"#D3FFA3\">[Console]</font> Report generated";
+			console.log(`log.mining${output}`);
+			return "[Console] Report generated";
 		};
 
 		help_log.push("log.spawn_assist()");
 
 		log.spawn_assist = function () {
-			console.log("<font color=\"#D3FFA3\">[Console]</font> Active Spawn Assists:");
+			console.log("[Console] Active Spawn Assists:");
 
 			let rooms = _.filter(Game.rooms, room => { return (room.controller != null && room.controller.my); });
-			let output = "<table><tr><th>Colony \t\t</th><th>Assisted By:</th></tr>";
+			let output = "	Colony \t\t		Assisted By:	";
 			for (let i = 0; i < rooms.length; i++) {
 				let room = rooms[i].name;
 				let spawn_rooms = _.get(Memory, ["rooms", room, "spawn_assist", "rooms"], null);
 				if (spawn_rooms != null) {
-					output += `<tr><td><font color=\"#D3FFA3\">${(room)}</font>: \t</td>`;
-					_.each(spawn_rooms, r => { output += `<td>${r} \t</td>`; });
-					output += `</tr>`;
+					output += `	${(room)}: \t	`;
+					_.each(spawn_rooms, r => { output += `	${r} \t	`; });
+					output += ``;
 				} else {
-					output += `<tr><td><font color=\"#D3FFA3\">${(room)}</font>: \t</td>`
-						+`<td>inactive</td></tr>`;
+					output += `	${(room)}: \t	`
+						+`	inactive	`;
 				}
 			}
-			console.log(`${output}</table>`);
-			return "<font color=\"#D3FFA3\">[Console]</font> Report generated";
+			console.log(`${output}`);
+			return "[Console] Report generated";
 		}
 
 		help_log.push("log.storage()");
 
 		log.storage = function () {
-			console.log(`<font color=\"#D3FFA3\">log-storage</font>`);
+			console.log(`log-storage`);
 
 			for (let i = 0; i < Object.keys(Game.rooms).length; i++) {
 				let room = Game.rooms[Object.keys(Game.rooms)[i]];
@@ -858,10 +858,10 @@
 					if (_.sum(room.storage) == 0) {
 						console.log(`${room.name} storage: empty`);
 					} else {
-						let output = `<font color=\"#D3FFA3\">${room.name}</font> storage (${parseInt(_.sum(room.storage.store) / room.storage.storeCapacity * 100)}%): `;
+						let output = `${room.name} storage (${parseInt(_.sum(room.storage.store) / room.storage.storeCapacity * 100)}%): `;
 						for (let res in room.storage.store) {
 							if (room.storage.store[res] > 0)
-								output += `<font color=\"#D3FFA3\">${res}</font>: ${_.floor(room.storage.store[res] / 1000)}k;  `;
+								output += `${res}: ${_.floor(room.storage.store[res] / 1000)}k;  `;
 						}
 						console.log(output);
 					}
@@ -871,35 +871,32 @@
 					if (_.sum(room.terminal) == 0) {
 						console.log(`${room.name} terminal: empty`);
 					} else {
-						let output = `<font color=\"#D3FFA3\">${room.name}</font> terminal (${parseInt(_.sum(room.terminal.store) / room.terminal.storeCapacity * 100)}%): `;
+						let output = `${room.name} terminal (${parseInt(_.sum(room.terminal.store) / room.terminal.storeCapacity * 100)}%): `;
 						for (let res in room.terminal.store) {
 							if (room.terminal.store[res] > 0)
-								output += `<font color=\"#D3FFA3\">${res}</font>: ${_.floor(room.terminal.store[res] / 1000)}k;  `;
+								output += `${res}: ${_.floor(room.terminal.store[res] / 1000)}k;  `;
 						}
 						console.log(output);
 					}
 				}
 			}
-			return "<font color=\"#D3FFA3\">[Console]</font> Report generated";
+			return "[Console] Report generated";
 		};
 
 		help_log.push("log.nukers()");
 
 		log.nukers = function () {
-			console.log("<font color=\"#D3FFA3\">[Console]</font> Nukers:");
+			console.log("[Console] Nukers:");
 			_.each(_.filter(Game.rooms, r => { return r.controller != null && r.controller.my; }), r => {
 				let nuker = _.head(r.find(FIND_STRUCTURES, { filter: (s) => { return s.structureType == "nuker"; } }));
 				if (nuker != null) {
-					console.log(`<font color=\"#D3FFA3\">${r.name}:</font> `
-						+ `<font color=\"#${nuker.cooldown == 0 ? "47FF3E" : "FF3E3E"}\">`
-						+ `cooldown: ${nuker.cooldown};</font>  `
-						+ `<font color=\"#${nuker.energy == nuker.energyCapacity ? "47FF3E" : "FF3E3E"}\">`
-						+ `energy: ${nuker.energy} (${parseFloat(nuker.energy / nuker.energyCapacity * 100).toFixed(0)}%);</font>  `
-						+ `<font color=\"#${nuker.ghodium == nuker.ghodiumCapacity ? "47FF3E" : "FF3E3E"}\">`
-						+ `ghodium: ${nuker.ghodium} (${parseFloat(nuker.ghodium / nuker.ghodiumCapacity * 100).toFixed(0)}%)</font>`);
+					console.log(`${r.name}: `
+						+ `${nuker.cooldown == 0 ? "[OK]" : "[!!]"} cooldown: ${nuker.cooldown};  `
+						+ `${nuker.energy == nuker.energyCapacity ? "[OK]" : "[!!]"} energy: ${nuker.energy} (${parseFloat(nuker.energy / nuker.energyCapacity * 100).toFixed(0)}%);  `
+						+ `${nuker.ghodium == nuker.ghodiumCapacity ? "[OK]" : "[!!]"} ghodium: ${nuker.ghodium} (${parseFloat(nuker.ghodium / nuker.ghodiumCapacity * 100).toFixed(0)}%)`);  
 				}
 			});
-			return "<font color=\"#D3FFA3\">[Console]</font> Report generated";
+			return "[Console] Report generated";
 		};
 
 
@@ -912,7 +909,7 @@
 		labs = new Object();
 		labs.set_reaction = function (mineral, amount, priority) {
 			_.set(Memory, ["resources", "labs", "targets", mineral], { mineral: mineral, amount: amount, priority: priority });
-			return `<font color=\"#D3FFA3\">[Console]</font> ${mineral} reaction target set to ${amount} (priority ${priority}).`;
+			return `[Console] ${mineral} reaction target set to ${amount} (priority ${priority}).`;
 		};
 
 		help_labs.push("labs.set_boost(labID, mineral, role, destination, ticks)");
@@ -938,7 +935,7 @@
 
 			_.set(Memory, ["rooms", rmName, "labs", "definitions"], labDefinitions);
 			delete Memory["hive"]["pulses"]["lab"];
-			return `<font color=\"#D3FFA3\">[Console]</font> Boost added for ${mineral} to ${role} from ${labID}`;
+			return `[Console] Boost added for ${mineral} to ${role} from ${labID}`;
 		};
 
 		help_labs.push("labs.clear_reactions()");
@@ -948,7 +945,7 @@
 		labs.clear_reactions = function () {
 			_.set(Memory, ["resources", "labs", "targets"], new Object());
 			delete Memory["hive"]["pulses"]["lab"];
-			return `<font color=\"#D3FFA3\">[Console]</font> All lab mineral targets cleared.`;
+			return `[Console] All lab mineral targets cleared.`;
 		};
 
 		help_labs.push("labs.clear_boosts(rmName)");
@@ -959,7 +956,7 @@
 		labs.clear_boosts = function (rmName) {
 			delete Memory["rooms"][rmName]["labs"]["definitions"];
 			delete Memory["hive"]["pulses"]["lab"];
-			return `<font color=\"#D3FFA3\">[Console]</font> All boosts cleared for ${rmName}`;
+			return `[Console] All boosts cleared for ${rmName}`;
 		};
 
 		help_labs.push("labs.renew_assignments()");
@@ -968,7 +965,7 @@
 
 		labs.renew_assignments = function () {
 			delete Memory["hive"]["pulses"]["lab"];
-			return `<font color=\"#D3FFA3\">[Console]</font> Labs will renew definitions and reaction assignments next tick.`;
+			return `[Console] Labs will renew definitions and reaction assignments next tick.`;
 		};
 
 		help_labs.push("labs.clear_assignments()");
@@ -977,7 +974,7 @@
 
 		labs.clear_assignments = function () {
 			delete Memory["resources"]["labs"]["reactions"];
-			return `<font color=\"#D3FFA3\">[Console]</font> Lab reaction assignments cleared- will reassign next lab pulse.`;
+			return `[Console] Lab reaction assignments cleared- will reassign next lab pulse.`;
 		};
 
 
@@ -988,7 +985,7 @@
 		resources = new Object();
 		resources.overflow_cap = function (amount) {
 			_.set(Memory, ["resources", "to_overflow"], amount);
-			return `<font color=\"#D3FFA3\">[Console]</font> Energy overflow cap set to ${amount}.`;
+			return `[Console] Energy overflow cap set to ${amount}.`;
 		};
 
 		help_resources.push("resources.market_cap(resource, capAmount)");
@@ -998,7 +995,7 @@
 
 		resources.market_cap = function (resource, amount) {
 			_.set(Memory, ["resources", "to_market", resource], amount);
-			return `<font color=\"#D3FFA3\">[Console]</font> ${resource} market overflow set to ${amount}.`;
+			return `[Console] ${resource} market overflow set to ${amount}.`;
 		};
 
 		help_resources.push("resources.send(orderName, rmFrom, rmTo, resource, amount)");
@@ -1009,7 +1006,7 @@
 
 		resources.send = function (orderName, rmFrom, rmTo, resource, amount) {
 			_.set(Memory, ["resources", "terminal_orders", orderName], { room: rmTo, from: rmFrom, resource: resource, amount: amount, priority: 1 });
-			return `<font color=\"#D3FFA3\">[Console]</font> Order set at Memory["resources"]["terminal_orders"][${orderName}]; delete from Memory to cancel.`;
+			return `[Console] Order set at Memory["resources"]["terminal_orders"][${orderName}]; delete from Memory to cancel.`;
 		};
 
 		help_resources.push("resources.market_sell(orderName, marketOrderID, rmFrom, amount)");
@@ -1020,7 +1017,7 @@
 
 		resources.market_sell = function (orderName, marketOrderID, rmFrom, amount) {
 			_.set(Memory, ["resources", "terminal_orders", orderName], { market_id: marketOrderID, amount: amount, from: rmFrom, priority: 4 });
-			return `<font color=\"#D3FFA3\">[Console]</font> Order set at Memory["resources"]["terminal_orders"][${orderName}]; delete from Memory to cancel.`;
+			return `[Console] Order set at Memory["resources"]["terminal_orders"][${orderName}]; delete from Memory to cancel.`;
 		};
 
 		help_resources.push("resources.market_buy(orderName, marketOrderID, rmTo, amount)");
@@ -1031,7 +1028,7 @@
 
 		resources.market_buy = function (orderName, marketOrderID, rmTo, amount) {
 			_.set(Memory, ["resources", "terminal_orders", orderName], { market_id: marketOrderID, amount: amount, to: rmTo, priority: 4 });
-			return `<font color=\"#D3FFA3\">[Console]</font> Order set at Memory["resources", "terminal_orders"][${orderName}]; delete from Memory to cancel.`;
+			return `[Console] Order set at Memory["resources", "terminal_orders"][${orderName}]; delete from Memory to cancel.`;
 		};
 
 		help_resources.push("resources.clear_market_cap()");
@@ -1040,7 +1037,7 @@
 
 		resources.clear_market_cap = function () {
 			_.set(Memory, ["resources", "to_market"], new Object());
-			return `<font color=\"#D3FFA3\">[Console]</font> Market overflow limits deleted; existing transactions can be deleted with resources.clear_transactions().`;
+			return `[Console] Market overflow limits deleted; existing transactions can be deleted with resources.clear_transactions().`;
 		};
 
 		help_resources.push("resources.clear_transactions()");
@@ -1049,7 +1046,7 @@
 
 		resources.clear_transactions = function () {
 			_.set(Memory, ["resources", "terminal_orders"], new Object());
-			return `<font color=\"#D3FFA3\">[Console]</font> All terminal transactions cleared.`;
+			return `[Console] All terminal transactions cleared.`;
 		};
 
 		help_resources.push("resources.set_energy_threshold(amount)");
@@ -1059,7 +1056,7 @@
 
 		resources.set_energy_threshold = function (amount) {
 			_.set(Memory, ["resources", "market_energy_threshold"], amount);
-			return `<font color=\"#D3FFA3\">[Console]</font> Market energy threshold set to ${amount}. Emergency market orders will trigger when total colony energy falls below this amount.`;
+			return `[Console] Market energy threshold set to ${amount}. Emergency market orders will trigger when total colony energy falls below this amount.`;
 		};
 
 		help_resources.push("resources.market_status()");
@@ -1080,7 +1077,7 @@
 			let statusColor = status === "OK" ? "#47FF3E" : "#FF6B6B";
 
 			// Energy Status Summary
-			console.log(`<font color=\"#D3FFA3\">[Market Status]</font> <b>Energy Status:</b> ${totalEnergy.toLocaleString()}/${energyThreshold.toLocaleString()} - <font color=\"${statusColor}\">${status}</font>`);
+			console.log(`[Market Status] Energy Status: ${totalEnergy.toLocaleString()}/${energyThreshold.toLocaleString()} - ${status}`);
 
 			// Terminal Orders Table (CSS)
 			let terminalOrders = _.get(Memory, ["resources", "terminal_orders"]);
@@ -1088,8 +1085,8 @@
 				let tableStyle = "style=\"border-collapse: collapse; border: 1px solid #666; margin: 5px 0; width: 100%;\"";
 				let cellStyle = "style=\"border: 1px solid #666; padding: 2px 6px; text-align: left; font-size: 12px;\"";
 				let headerStyle = "style=\"border: 1px solid #666; padding: 2px 6px; text-align: left; background-color: #444; color: #D3FFA3; font-weight: bold; font-size: 13px;\"";
-				console.log(`<font color=\"#D3FFA3\">[Market Status]</font> <b>Terminal Orders:</b> ${Object.keys(terminalOrders).length}`);
-				let ordersTable = `<table ${tableStyle}><tr><th ${headerStyle}>Order Name</th><th ${headerStyle}>Type</th><th ${headerStyle}>Resource</th><th ${headerStyle}>Amount</th><th ${headerStyle}>Priority</th><th ${headerStyle}>Room</th></tr>`;
+				console.log(`[Market Status] Terminal Orders: ${Object.keys(terminalOrders).length}`);
+				let ordersTable = `	Order Name		Type		Resource		Amount		Priority		Room	`;
 				_.each(terminalOrders, (order, orderName) => {
 					let orderType = order.market_id ? "Market" : "Internal";
 					let emergency = order.emergency ? " (EMERGENCY)" : "";
@@ -1097,12 +1094,12 @@
 					let resource = order.resource || "";
 					let amount = order.amount || "";
 					let room = order.room || order.to || order.from || "";
-					ordersTable += `<tr><td ${cellStyle}>${orderName}</td><td ${cellStyle}>${orderType}${emergency}</td><td ${cellStyle}>${resource}</td><td ${cellStyle}>${amount}</td><td ${cellStyle}>${priority}</td><td ${cellStyle}>${room}</td></tr>`;
+					ordersTable += `	${orderName}		${orderType}${emergency}		${resource}		${amount}		${priority}		${room}	`;
 				});
-				ordersTable += "</table>";
+				ordersTable += "";
 				console.log(ordersTable);
 			} else {
-				console.log(`<font color=\"#D3FFA3\">[Market Status]</font> <b>No active terminal orders.</b>`);
+				console.log(`[Market Status] No active terminal orders.`);
 			}
 
 			// Available Market Orders Summary with Price Analysis
@@ -1126,43 +1123,43 @@
 				let reasonableOrders = energyOrders.filter(order => order.price <= reasonablePrice);
 				let expensiveOrders = energyOrders.filter(order => order.price > reasonablePrice);
 				
-				console.log(`<font color=\"#D3FFA3\">[Market Status]</font> <b>Energy Market Analysis:</b>`);
-				console.log(`  <b>Price Stats:</b> Min: ${minPrice.toFixed(2)}, Avg: ${avgPrice.toFixed(2)}, Median: ${medianPrice.toFixed(2)}, Max: ${maxPrice.toFixed(2)}`);
-				console.log(`  <b>Reasonable Price Threshold:</b> ${reasonablePrice.toFixed(2)} (${priceProtection.avg_multiplier}x avg or ${priceProtection.median_multiplier}x median, whichever is lower)`);
-				console.log(`  <b>Available Orders:</b> ${reasonableOrders.length} reasonable, ${expensiveOrders.length} too expensive`);
+				console.log(`[Market Status] Energy Market Analysis:`);
+				console.log(`  Price Stats: Min: ${minPrice.toFixed(2)}, Avg: ${avgPrice.toFixed(2)}, Median: ${medianPrice.toFixed(2)}, Max: ${maxPrice.toFixed(2)}`);
+				console.log(`  Reasonable Price Threshold: ${reasonablePrice.toFixed(2)} (${priceProtection.avg_multiplier}x avg or ${priceProtection.median_multiplier}x median, whichever is lower)`);
+				console.log(`  Available Orders: ${reasonableOrders.length} reasonable, ${expensiveOrders.length} too expensive`);
 				
 				if (reasonableOrders.length > 0) {
-					console.log(`<font color=\"#D3FFA3\">[Market Status]</font> <b>Top Reasonable Energy Orders:</b>`);
+					console.log(`[Market Status] Top Reasonable Energy Orders:`);
 					_.each(_.sortBy(reasonableOrders, order => order.price).slice(0, 5), (order, i) => {
 						console.log(`  ${i+1}. ${order.amount.toLocaleString()} energy @ ${order.price} credits from ${order.roomName}`);
 					});
 				} else {
-					console.log(`<font color=\"#FF6B6B\">[Market Status]</font> <b>⚠️ No reasonable energy orders available!</b> All orders are too expensive.`);
+					console.log(`[Market Status] ⚠️ No reasonable energy orders available! All orders are too expensive.`);
 				}
 				
 				if (expensiveOrders.length > 0) {
-					console.log(`<font color=\"#FFA500\">[Market Status]</font> <b>Expensive Orders (skipped):</b>`);
+					console.log(`[Market Status] Expensive Orders (skipped):`);
 					_.each(_.sortBy(expensiveOrders, order => order.price).slice(0, 3), (order, i) => {
 						console.log(`  ${i+1}. ${order.amount.toLocaleString()} energy @ ${order.price} credits from ${order.roomName} (${((order.price / avgPrice) * 100).toFixed(0)}% of avg)`);
 					});
 				}
 			} else {
-				console.log(`<font color=\"#D3FFA3\">[Market Status]</font> <b>No energy sell orders available on market.</b>`);
+				console.log(`[Market Status] No energy sell orders available on market.`);
 			}
 
 			// Credit Status
 			let availableCredits = Game.market.credits || 0;
-			console.log(`<font color=\"#D3FFA3\">[Market Status]</font> <b>Available Credits:</b> ${availableCredits.toLocaleString()}`);
+			console.log(`[Market Status] Available Credits: ${availableCredits.toLocaleString()}`);
 
 			// CPU Usage Information
 			let cpuUsed = Game.cpu.getUsed();
 			let cpuBucket = Game.cpu.bucket;
-			console.log(`<font color=\"#D3FFA3\">[Market Status]</font> <b>CPU Status:</b> Used: ${cpuUsed.toFixed(2)}, Bucket: ${cpuBucket.toFixed(0)}`);
+			console.log(`[Market Status] CPU Status: Used: ${cpuUsed.toFixed(2)}, Bucket: ${cpuBucket.toFixed(0)}`);
 
 			// Emergency Status with Enhanced Information
 			if (totalEnergy < energyThreshold) {
 				let nextCheckTick = Math.ceil(Game.time / 50) * 50 + 1;
-				console.log(`<font color=\"#FF6B6B\">[Market Status]</font> <b>⚠️ Emergency:</b> Energy below threshold! Next check at tick ${nextCheckTick}`);
+				console.log(`[Market Status] ⚠️ Emergency: Energy below threshold! Next check at tick ${nextCheckTick}`);
 				
 				// Show why we might not be buying
 				if (energyOrders.length > 0) {
@@ -1174,13 +1171,13 @@
 					let reasonableOrders = energyOrders.filter(order => order.price <= reasonablePrice);
 					
 					if (reasonableOrders.length == 0) {
-						console.log(`<font color=\"#FFA500\">[Market Status]</font> <b>Reason for not buying:</b> All energy orders are too expensive (above ${reasonablePrice.toFixed(2)} credits)`);
+						console.log(`[Market Status] Reason for not buying: All energy orders are too expensive (above ${reasonablePrice.toFixed(2)} credits)`);
 					} else {
 						let bestOrder = _.sortBy(reasonableOrders, order => order.price)[0];
 						let totalCost = bestOrder.price * 5000; // Estimate cost for 5000 energy
 						
 						if (totalCost > availableCredits * creditLimit) {
-							console.log(`<font color=\"#FFA500\">[Market Status]</font> <b>Reason for not buying:</b> Insufficient credits. Need ~${totalCost.toLocaleString()} credits, have ${availableCredits.toLocaleString()} (limit: ${(creditLimit * 100).toFixed(0)}%)`);
+							console.log(`[Market Status] Reason for not buying: Insufficient credits. Need ~${totalCost.toLocaleString()} credits, have ${availableCredits.toLocaleString()} (limit: ${(creditLimit * 100).toFixed(0)}%)`);
 						}
 					}
 				}
@@ -1189,7 +1186,7 @@
 			// Transaction Cost Analysis
 			if (energyOrders.length > 0) {
 				let bestOrder = _.sortBy(energyOrders, order => order.price)[0];
-				console.log(`<font color=\"#D3FFA3\">[Market Status]</font> <b>Transaction Cost Analysis (Best Order: ${bestOrder.price} credits):</b>`);
+				console.log(`[Market Status] Transaction Cost Analysis (Best Order: ${bestOrder.price} credits):`);
 				
 				_.each(colonies, colony => {
 					if (colony.terminal && colony.terminal.my) {
@@ -1203,7 +1200,7 @@
 						let statusColor = netGain > 0 ? "#47FF3E" : "#FF6B6B";
 						let energyStatus = terminalEnergy >= energyCost ? "✅" : "⚠️";
 						
-						console.log(`  ${colony.name}: ${energyStatus} Terminal energy: ${terminalEnergy}, Cost for ${sampleAmount} energy: ${energyCost} (${costPerUnit.toFixed(3)} per unit), Net gain: ${netGain} (<font color=\"${statusColor}\">${profitMargin.toFixed(1)}% profit</font>)`);
+						console.log(`  ${colony.name}: ${energyStatus} Terminal energy: ${terminalEnergy}, Cost for ${sampleAmount} energy: ${energyCost} (${costPerUnit.toFixed(3)} per unit), Net gain: ${netGain} (${profitMargin.toFixed(1)}% profit)`);
 						
 						if (terminalEnergy < energyCost) {
 							console.log(`    ⚠️  Terminal needs ${energyCost - terminalEnergy} more energy for transaction`);
@@ -1212,7 +1209,7 @@
 				});
 			}
 
-		return `<font color=\"#D3FFA3\">[Console]</font> Market status displayed.`;
+		return `[Console] Market status displayed.`;
 	};
 
 	help_resources.push("resources.check_dropped()");
@@ -1223,14 +1220,14 @@
 	resources.check_dropped = function () {
 		let colonies = _.filter(Game.rooms, r => r.controller && r.controller.my);
 		let totalDropped = {};
-		let detailOutput = "<font color=\"#D3FFA3\">[Dropped Resources]</font> <b>Scanning all owned rooms...</b><br>";
+		let detailOutput = "[Dropped Resources] Scanning all owned rooms...\n";
 		
 		_.each(colonies, room => {
 			let dropped = room.find(FIND_DROPPED_RESOURCES);
 			if (dropped.length > 0) {
-				detailOutput += `<font color=\"#FFD700\">${room.name}</font>:<br>`;
+				detailOutput += `${room.name}:\n`;
 				_.each(dropped, pile => {
-					detailOutput += `  - ${pile.resourceType}: ${pile.amount} at (${pile.pos.x}, ${pile.pos.y})<br>`;
+					detailOutput += `  - ${pile.resourceType}: ${pile.amount} at (${pile.pos.x}, ${pile.pos.y})\n`;
 					totalDropped[pile.resourceType] = (totalDropped[pile.resourceType] || 0) + pile.amount;
 				});
 			}
@@ -1239,16 +1236,16 @@
 		console.log(detailOutput);
 		
 		if (Object.keys(totalDropped).length > 0) {
-			let summaryOutput = "<font color=\"#D3FFA3\">[Dropped Resources]</font> <b>Summary:</b><br>";
+			let summaryOutput = "[Dropped Resources] Summary:\n";
 			_.each(Object.keys(totalDropped).sort(), resourceType => {
-				summaryOutput += `  ${resourceType}: ${totalDropped[resourceType]} total<br>`;
+				summaryOutput += `  ${resourceType}: ${totalDropped[resourceType]} total\n`;
 			});
 			console.log(summaryOutput);
 		} else {
-			console.log("<font color=\"#D3FFA3\">[Dropped Resources]</font> <b>No dropped resources found.</b>");
+			console.log("[Dropped Resources] No dropped resources found.");
 		}
 		
-		return `<font color=\"#D3FFA3\">[Console]</font> Dropped resource scan complete.`;
+		return `[Console] Dropped resource scan complete.`;
 	};
 
 	help_resources.push("resources.clear_emergency_orders()");
@@ -1266,7 +1263,7 @@
 					}
 				});
 			}
-			return `<font color=\"#D3FFA3\">[Console]</font> Cleared ${cleared} emergency market orders.`;
+			return `[Console] Cleared ${cleared} emergency market orders.`;
 		};
 
 		help_resources.push("resources.force_emergency_orders()");
@@ -1281,9 +1278,9 @@
 		resources.set_market_config = function(key, value) {
 			if (key === 'market_min_energy_gain') {
 				_.set(Memory, ["resources", key], parseInt(value));
-				return `<font color=\"#D3FFA3\">[Console]</font> Set ${key} to ${value}.`;
+				return `[Console] Set ${key} to ${value}.`;
 			} else {
-				return `<font color=\"#FF6B6B\">[Console]</font> Unknown config key: ${key}. Available: market_min_energy_gain`;
+				return `[Console] Unknown config key: ${key}. Available: market_min_energy_gain`;
 			}
 		};
 
@@ -1297,7 +1294,7 @@
 			let cpuLimit = Game.cpu.limit;
 			let cpuPercent = (cpuUsed / cpuLimit) * 100;
 			
-			console.log(`<font color=\"#D3FFA3\">[System Status]</font> <b>CPU Performance:</b>`);
+			console.log(`[System Status] CPU Performance:`);
 			console.log(`  Used: ${cpuUsed.toFixed(2)}/${cpuLimit} (${cpuPercent.toFixed(1)}%)`);
 			console.log(`  Bucket: ${cpuBucket.toFixed(0)}`);
 			console.log(`  Status: ${cpuPercent > 80 ? "⚠️ High" : cpuPercent > 60 ? "⚡ Medium" : "✅ Good"}`);
@@ -1305,14 +1302,14 @@
 			// Memory Usage
 			let memorySize = JSON.stringify(Memory).length;
 			let memoryKB = (memorySize / 1024).toFixed(1);
-			console.log(`<font color=\"#D3FFA3\">[System Status]</font> <b>Memory Usage:</b> ${memoryKB} KB`);
+			console.log(`[System Status] Memory Usage: ${memoryKB} KB`);
 			
 			// Colony Status
 			let colonies = _.filter(Game.rooms, r => r.controller && r.controller.my);
 			let totalCreeps = Object.keys(Game.creeps).length;
 			let totalStructures = Object.keys(Game.structures).length;
 			
-			console.log(`<font color=\"#D3FFA3\">[System Status]</font> <b>Colony Status:</b>`);
+			console.log(`[System Status] Colony Status:`);
 			console.log(`  Colonies: ${colonies.length}`);
 			console.log(`  Creeps: ${totalCreeps}`);
 			console.log(`  Structures: ${totalStructures}`);
@@ -1322,20 +1319,20 @@
 			_.each(colonies, colony => {
 				totalEnergy += colony.store("energy");
 			});
-			console.log(`<font color=\"#D3FFA3\">[System Status]</font> <b>Total Energy:</b> ${totalEnergy.toLocaleString()}`);
+			console.log(`[System Status] Total Energy: ${totalEnergy.toLocaleString()}`);
 			
 			// Market Status
 			let availableCredits = Game.market.credits || 0;
-			console.log(`<font color=\"#D3FFA3\">[System Status]</font> <b>Market Credits:</b> ${availableCredits.toLocaleString()}`);
+			console.log(`[System Status] Market Credits: ${availableCredits.toLocaleString()}`);
 			
 			// Pulse Status
-			console.log(`<font color=\"#D3FFA3\">[System Status]</font> <b>Pulse Status:</b>`);
+			console.log(`[System Status] Pulse Status:`);
 			console.log(`  Defense: ${isPulse_Defense() ? "✅ Active" : "⏸️ Inactive"}`);
 			console.log(`  Short: ${isPulse_Short() ? "✅ Active" : "⏸️ Inactive"}`);
 			console.log(`  Mid: ${isPulse_Mid() ? "✅ Active" : "⏸️ Inactive"}`);
 			console.log(`  Spawn: ${isPulse_Spawn() ? "✅ Active" : "⏸️ Inactive"}`);
 			
-			return `<font color=\"#D3FFA3\">[System Status]</font> System status displayed.`;
+			return `[System Status] System status displayed.`;
 		};
 
 		help_resources.push("resources.fuel_terminals()");
@@ -1362,19 +1359,19 @@
 							emergency: true
 						});
 						fueled++;
-						console.log(`<font color=\"#D3FFA3\">[Console]</font> Created terminal fuel order for ${colony.name}: ${energyNeeded} energy (current: ${terminalEnergy})`);
+						console.log(`[Console] Created terminal fuel order for ${colony.name}: ${energyNeeded} energy (current: ${terminalEnergy})`);
 					}
 				}
 			});
 			
-			return `<font color=\"#D3FFA3\">[Console]</font> Created ${fueled} terminal fuel orders.`;
+			return `[Console] Created ${fueled} terminal fuel orders.`;
 		};
 
 		resources.force_emergency_orders = function () {
 			// Find a room with a terminal to trigger the emergency order creation
 			let roomWithTerminal = _.find(Game.rooms, r => r.controller && r.controller.my && r.terminal);
 			if (!roomWithTerminal) {
-				return `<font color=\"#D3FFA3\">[Console]</font> Error: No room with terminal found.`;
+				return `[Console] Error: No room with terminal found.`;
 			}
 
 			// Implement the emergency order creation logic directly
@@ -1415,14 +1412,14 @@
 							
 							// Check if this transaction is profitable
 							if (netEnergyGained <= 0) {
-								console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: Transaction not profitable: buying ${amountToBuy} energy costs ${energyCost} energy (net gain: ${netEnergyGained}). Skipping.`);
+								console.log(`[Market Emergency] Manual trigger: Transaction not profitable: buying ${amountToBuy} energy costs ${energyCost} energy (net gain: ${netEnergyGained}). Skipping.`);
 								return;
 							}
 							
 							// Check if the energy gain is significant enough
 							let minSignificantGain = _.get(Memory, ["resources", "market_min_energy_gain"], 1000);
 							if (netEnergyGained < minSignificantGain) {
-								console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: Energy gain too small: ${netEnergyGained} net energy (minimum: ${minSignificantGain}). Skipping.`);
+								console.log(`[Market Emergency] Manual trigger: Energy gain too small: ${netEnergyGained} net energy (minimum: ${minSignificantGain}). Skipping.`);
 								return;
 							}
 							
@@ -1456,7 +1453,7 @@
 									terminal_fuel: true,
 									emergency: true
 								});
-								console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: Terminal in ${roomWithTerminal.name} needs ${energyNeeded} energy for transaction. Creating high-priority energy order.`);
+								console.log(`[Market Emergency] Manual trigger: Terminal in ${roomWithTerminal.name} needs ${energyNeeded} energy for transaction. Creating high-priority energy order.`);
 								return;
 							}
 							
@@ -1472,21 +1469,21 @@
 								net_gain: netEnergyGained
 							});
 
-							console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: Creating market buy order: ${amountToBuy} energy at ${bestOrder.price} credits (cost: ${energyCost} energy, net gain: ${netEnergyGained}) to ${bestReceivingRoom} (terminal energy: ${bestRoomEnergy}).`);
+							console.log(`[Market Emergency] Manual trigger: Creating market buy order: ${amountToBuy} energy at ${bestOrder.price} credits (cost: ${energyCost} energy, net gain: ${netEnergyGained}) to ${bestReceivingRoom} (terminal energy: ${bestRoomEnergy}).`);
 						} else {
-							console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: Insufficient credits. Need ${totalCost} credits, have ${availableCredits}.`);
+							console.log(`[Market Emergency] Manual trigger: Insufficient credits. Need ${totalCost} credits, have ${availableCredits}.`);
 						}
 					} else {
-						console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: All energy orders too expensive. Average price: ${avgPrice.toFixed(2)}, max acceptable: ${maxPrice.toFixed(2)}.`);
+						console.log(`[Market Emergency] Manual trigger: All energy orders too expensive. Average price: ${avgPrice.toFixed(2)}, max acceptable: ${maxPrice.toFixed(2)}.`);
 					}
 				} else {
-					console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: No energy sell orders available on market.`);
+					console.log(`[Market Emergency] Manual trigger: No energy sell orders available on market.`);
 				}
 			} else {
-				console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: Energy above threshold (${totalEnergy}/${energyThreshold}).`);
+				console.log(`[Market Emergency] Manual trigger: Energy above threshold (${totalEnergy}/${energyThreshold}).`);
 			}
 			
-			return `<font color=\"#D3FFA3\">[Console]</font> Emergency order creation triggered for ${roomWithTerminal.name}.`;
+			return `[Console] Emergency order creation triggered for ${roomWithTerminal.name}.`;
 		};
 
 		help_resources.push("resources.clear_and_force_emergency()");
@@ -1566,21 +1563,21 @@
 								emergency: true
 							});
 
-							console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: Creating market buy order for ${amountToBuy} energy at ${bestOrder.price} credits to ${bestReceivingRoom} (terminal energy: ${bestRoomEnergy}).`);
+							console.log(`[Market Emergency] Manual trigger: Creating market buy order for ${amountToBuy} energy at ${bestOrder.price} credits to ${bestReceivingRoom} (terminal energy: ${bestRoomEnergy}).`);
 						} else {
-							console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: Insufficient credits. Need ${totalCost} credits, have ${availableCredits}.`);
+							console.log(`[Market Emergency] Manual trigger: Insufficient credits. Need ${totalCost} credits, have ${availableCredits}.`);
 						}
 					} else {
-						console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: All energy orders too expensive. Average price: ${avgPrice.toFixed(2)}, max acceptable: ${maxPrice.toFixed(2)}.`);
+						console.log(`[Market Emergency] Manual trigger: All energy orders too expensive. Average price: ${avgPrice.toFixed(2)}, max acceptable: ${maxPrice.toFixed(2)}.`);
 					}
 				} else {
-					console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: No energy sell orders available on market.`);
+					console.log(`[Market Emergency] Manual trigger: No energy sell orders available on market.`);
 				}
 			} else {
-				console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Manual trigger: Energy above threshold (${totalEnergy}/${energyThreshold}).`);
+				console.log(`[Market Emergency] Manual trigger: Energy above threshold (${totalEnergy}/${energyThreshold}).`);
 			}
 			
-			return `<font color=\"#D3FFA3\">[Console]</font> Cleared ${cleared} emergency orders and triggered new emergency order creation.`;
+			return `[Console] Cleared ${cleared} emergency orders and triggered new emergency order creation.`;
 		};
 
 		help_resources.push("resources.set_price_protection(avgMultiplier, medianMultiplier)");
@@ -1594,7 +1591,7 @@
 				avg_multiplier: avgMultiplier || 2.0,
 				median_multiplier: medianMultiplier || 1.5
 			});
-			return `<font color=\"#D3FFA3\">[Console]</font> Price protection set to ${avgMultiplier || 2.0}x average and ${medianMultiplier || 1.5}x median.`;
+			return `[Console] Price protection set to ${avgMultiplier || 2.0}x average and ${medianMultiplier || 1.5}x median.`;
 		};
 
 		help_resources.push("resources.set_credit_limit(percentage)");
@@ -1604,10 +1601,10 @@
 
 		resources.set_credit_limit = function (percentage) {
 			if (percentage < 0 || percentage > 100) {
-				return `<font color=\"#FF6B6B\">[Console]</font> Error: Percentage must be between 0 and 100.`;
+				return `[Console] Error: Percentage must be between 0 and 100.`;
 			}
 			_.set(Memory, ["resources", "market_credit_limit"], percentage / 100);
-			return `<font color=\"#D3FFA3\">[Console]</font> Credit limit set to ${percentage}% of available credits.`;
+			return `[Console] Credit limit set to ${percentage}% of available credits.`;
 		};
 
 		help_resources.push("resources.credits()");
@@ -1619,11 +1616,11 @@
 			let creditLimit = _.get(Memory, ["resources", "market_credit_limit"], 0.8);
 			let maxSpendable = availableCredits * creditLimit;
 			
-			console.log(`<font color=\"#D3FFA3\">[Credits]</font> <b>Available Credits:</b> ${availableCredits.toLocaleString()}`);
-			console.log(`<font color=\"#D3FFA3\">[Credits]</font> <b>Credit Limit:</b> ${(creditLimit * 100).toFixed(0)}%`);
-			console.log(`<font color=\"#D3FFA3\">[Credits]</font> <b>Max Spendable:</b> ${maxSpendable.toLocaleString()}`);
+			console.log(`[Credits] Available Credits: ${availableCredits.toLocaleString()}`);
+			console.log(`[Credits] Credit Limit: ${(creditLimit * 100).toFixed(0)}%`);
+			console.log(`[Credits] Max Spendable: ${maxSpendable.toLocaleString()}`);
 			
-			return `<font color=\"#D3FFA3\">[Console]</font> Credit information displayed.`;
+			return `[Console] Credit information displayed.`;
 		};
 
 
@@ -1643,7 +1640,7 @@
 					colony: colony, target_room: target_room, list_spawns: list_spawns,
 					list_route: list_route, tactic: tactic
 				});
-			return `<font color=\"#D3FFA3\">[Console]</font> Combat request added to Memory.sites.combat.${combat_id} ... to cancel, delete the entry.`;
+			return `[Console] Combat request added to Memory.sites.combat.${combat_id} ... to cancel, delete the entry.`;
 		};
 
 		help_empire.push("");
@@ -1651,14 +1648,14 @@
 		help_empire.push("empire.set_threat(roomName, level)  ... NONE, LOW, MEDIUM, HIGH")
 		empire.set_threat = function (room_name, level) {
 			_.set(Memory, ["rooms", room_name, "defense", "threat_level"], level);
-			return `<font color=\"#D3FFA3\">[Console]</font> Threat level for room ${room_name} set.`;
+			return `[Console] Threat level for room ${room_name} set.`;
 		};
 
 		help_empire.push("empire.set_threat_all(level)  ... NONE, LOW, MEDIUM, HIGH")
 		empire.set_threat_all = function (level) {
 			for (let i in Memory.rooms)
 				_.set(Memory, ["rooms", i, "defense", "threat_level"], level);
-			return `<font color=\"#D3FFA3\">[Console]</font> Threat level for all rooms set.`;
+			return `[Console] Threat level for all rooms set.`;
 		};
 
 		help_empire.push("empire.wall_target(hitpoints)  ... hitpoints can be null to reset")
@@ -1667,18 +1664,18 @@
 				for (let i in Memory.rooms)
 					if (_.has(Memory, ["rooms", i, "defense", "wall_hp_target"]))
 						delete Memory["rooms"][i]["defense"]["wall_hp_target"];
-				return `<font color=\"#D3FFA3\">[Console]</font> Wall/rampart hitpoint target reset to default for all rooms.`;
+				return `[Console] Wall/rampart hitpoint target reset to default for all rooms.`;
 			} else {
 				for (let i in Memory.rooms)
 					_.set(Memory, ["rooms", i, "defense", "wall_hp_target"], hitpoints);
-				return `<font color=\"#D3FFA3\">[Console]</font> Wall/rampart hitpoint target set for all rooms.`;
+				return `[Console] Wall/rampart hitpoint target set for all rooms.`;
 			}
 		};
 
 		help_empire.push("empire.set_camp(room_pos)")
 		empire.set_camp = function (room_pos) {
 			_.set(Memory, ["rooms", room_pos.roomName, "camp"], room_pos);
-			return `<font color=\"#D3FFA3\">[Console]</font> Defensive camp set for room ${room_pos.roomName}.`;
+			return `[Console] Defensive camp set for room ${room_pos.roomName}.`;
 		};
 
 		help_empire.push("");
@@ -1686,22 +1683,22 @@
 
 		empire.colonize = function (from, target, layout, focus_defense, list_route) {
 			_.set(Memory, ["sites", "colonization", target], { from: from, target: target, layout: layout, focus_defense: focus_defense, list_route: list_route });
-			return `<font color=\"#D3FFA3\">[Console]</font> Colonization request added to Memory.sites.colonization.${target} ... to cancel, delete the entry.`;
+			return `[Console] Colonization request added to Memory.sites.colonization.${target} ... to cancel, delete the entry.`;
 		};
 
 		help_empire.push("empire.spawn_assist(rmToAssist, [listRooms], [listRoute])");
 		empire.spawn_assist = function (room_assist, list_rooms, list_route) {
 			_.set(Memory, ["rooms", room_assist, "spawn_assist"], { rooms: list_rooms, list_route: list_route });
-			return `<font color=\"#D3FFA3\">[Console]</font> Spawn assist added to Memory.rooms.${room_assist}.spawn_assist ... to cancel, delete the entry.`;
+			return `[Console] Spawn assist added to Memory.rooms.${room_assist}.spawn_assist ... to cancel, delete the entry.`;
 		};
 
 		help_empire.push("empire.remote_mining(rmColony, rmHarvest, hasKeepers, [listRoute], [listSpawnAssistRooms], {customPopulation})");
 		empire.remote_mining = function (rmColony, rmHarvest, hasKeepers, listRoute, listSpawnAssistRooms, customPopulation) {
 			if (rmColony == null || rmHarvest == null)
-				return `<font color=\"#D3FFA3\">[Console]</font> Error, invalid entry for remote_mining()`;
+				return `[Console] Error, invalid entry for remote_mining()`;
 
 			_.set(Memory, ["sites", "mining", rmHarvest], { colony: rmColony, has_keepers: hasKeepers, list_route: listRoute, spawn_assist: listSpawnAssistRooms, population: customPopulation });
-			return `<font color=\"#D3FFA3\">[Console]</font> Remote mining added to Memory.sites.mining.${rmHarvest} ... to cancel, delete the entry.`;
+			return `[Console] Remote mining added to Memory.sites.mining.${rmHarvest} ... to cancel, delete the entry.`;
 		};
 		help_empire.push("empire.scout(rmColony, rally_pos, dest_pos, { count, respawn, waitForFullRally, priority, level, body, name, spawnRooms, patrol_mode, transfer_intent, global, listRoute, rallyShard, destShard })");
 		help_empire.push(" - rally_pos / dest_pos accept RoomPosition or plain objects ({ x, y, roomName, shard? })");
@@ -1995,7 +1992,7 @@
 
 			let parsedColony = parseShardRoom(rmColony, Game.shard.name);
 			if (!_.isString(parsedColony.roomName))
-				return `<font color=\"#FF4E50\">[Console]</font> Error: Invalid rmColony ${rmColony}.`;
+				return `[Console] Error: Invalid rmColony ${rmColony}.`;
 
 			let colonyShard = parsedColony.shard;
 			let colonyRoomName = parsedColony.roomName;
@@ -2003,7 +2000,7 @@
 			if (colonyShard === Game.shard.name) {
 				let colonyRoom = _.get(Game, ["rooms", colonyRoomName]);
 				if (!colonyRoom || !_.get(colonyRoom, ["controller", "my"]))
-					return `<font color=\"#FF4E50\">[Console]</font> Error: rmColony ${colonyRoomName} is not under our control.`;
+					return `[Console] Error: rmColony ${colonyRoomName} is not under our control.`;
 			}
 
 			options = (options && typeof options === "object") ? options : {};
@@ -2015,9 +2012,9 @@
 			let packedDest = packPos(dest_pos, destShardHint);
 
 			if (!packedRally)
-				return `<font color=\"#FF4E50\">[Console]</font> Error: rally_pos must include x, y, roomName.`;
+				return `[Console] Error: rally_pos must include x, y, roomName.`;
 			if (!packedDest)
-				return `<font color=\"#FF4E50\">[Console]</font> Error: dest_pos must include x, y, roomName.`;
+				return `[Console] Error: dest_pos must include x, y, roomName.`;
 
 			let rallyShard = packedRally.shard || rallyShardHint;
 			let destShard = packedDest.shard || destShardHint;
@@ -2084,7 +2081,7 @@
 
 			if (!mission.list_route) {
 				if (colonyShard !== destShard) {
-					console.log(`<font color=\"#FF944E\">[Scout]</font> Warning: cross-shard scout mission ${mission.id} has no listRoute; please supply options.listRoute to guide portal approach.`);
+					console.log(`[Scout] Warning: cross-shard scout mission ${mission.id} has no listRoute; please supply options.listRoute to guide portal approach.`);
 				} else {
 					let derivedRoute = [colonyRoomName];
 					try {
@@ -2099,7 +2096,7 @@
 							derivedRoute.push(packedDest.roomName);
 						}
 					} catch (err) {
-						console.log(`<font color=\"#FF944E\">[Scout]</font> Warning: Unable to derive route for ${colonyRoomName} -> ${packedDest.roomName}; ${err}`);
+						console.log(`[Scout] Warning: Unable to derive route for ${colonyRoomName} -> ${packedDest.roomName}; ${err}`);
 					}
 					if (_.last(derivedRoute) !== packedDest.roomName)
 						derivedRoute.push(packedDest.roomName);
@@ -2133,7 +2130,7 @@
 			requests.push(mission);
 			_.set(Memory, ["rooms", colonyRoomName, "scout_requests"], requests);
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Scout mission ${mission.id} queued for ${colonyRoomName} -> ${packedDest.roomName}.`;
+			return `[Console] Scout mission ${mission.id} queued for ${colonyRoomName} -> ${packedDest.roomName}.`;
 		};
 
 		help_empire.push("empire.set_sign(message)")
@@ -2154,10 +2151,10 @@
 
 			if (rmName != null) {
 				_.set(Memory, ["hive", "signs", rmName], message);
-				return `<font color=\"#D3FFA3\">[Console]</font> Message for ${rmName} set.`;
+				return `[Console] Message for ${rmName} set.`;
 			} else {
 				_.set(Memory, ["hive", "signs", "default"], message);
-				return `<font color=\"#D3FFA3\">[Console]</font> Default message set.`;
+				return `[Console] Default message set.`;
 			}
 		};
 
@@ -2166,7 +2163,7 @@
 		empire.upgrader_status = function (roomName) {
 			let room = Game.rooms[roomName];
 			if (!room || !room.controller || !room.controller.my) {
-				return `<font color=\"#D3FFA3\">[Console]</font> Error: Room ${roomName} not found or not controlled.`;
+				return `[Console] Error: Room ${roomName} not found or not controlled.`;
 			}
 
 			let upgraders = _.filter(Game.creeps, c => c.memory.role == "upgrader" && c.memory.room == roomName);
@@ -2191,7 +2188,7 @@
 			let additionalUpgraders = Math.floor(remoteMiningSources / 2);
 			let totalExpectedUpgraders = baseUpgraders + additionalUpgraders;
 
-			console.log(`<font color=\"#D3FFA3\">[Console]</font> <b>Upgrader Status for ${roomName}:</b>`);
+			console.log(`[Console] Upgrader Status for ${roomName}:`);
 			console.log(`Room Level: ${roomLevel}, Controller Progress: ${controllerProgress}/${controllerProgressTotal}`);
 			console.log(`Active Upgraders: ${upgraders.length}/${totalExpectedUpgraders}`);
 			console.log(`Remote Mining: ${remoteRooms.length} rooms, ${remoteMiningSources} sources`);
@@ -2204,24 +2201,24 @@
 				});
 			}
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Upgrader status displayed for ${roomName}.`;
+			return `[Console] Upgrader status displayed for ${roomName}.`;
 		};
 
 		help_empire.push("empire.upgrader_force_spawn(roomName, amount)")
 		empire.upgrader_force_spawn = function (roomName, amount) {
 			let room = Game.rooms[roomName];
 			if (!room || !room.controller || !room.controller.my) {
-				return `<font color=\"#D3FFA3\">[Console]</font> Error: Room ${roomName} not found or not controlled.`;
+				return `[Console] Error: Room ${roomName} not found or not controlled.`;
 			}
 
 			_.set(Memory, ["rooms", roomName, "upgrader_force_spawn"], { amount: amount, timestamp: Game.time });
-			return `<font color=\"#D3FFA3\">[Console]</font> Force spawn ${amount} upgraders in ${roomName} next tick.`;
+			return `[Console] Force spawn ${amount} upgraders in ${roomName} next tick.`;
 		};
 
 		help_empire.push("empire.upgrader_clear_force_spawn(roomName)")
 		empire.upgrader_clear_force_spawn = function (roomName) {
 			delete Memory.rooms[roomName].upgrader_force_spawn;
-			return `<font color=\"#D3FFA3\">[Console]</font> Force spawn cleared for ${roomName}.`;
+			return `[Console] Force spawn cleared for ${roomName}.`;
 		};
 
 		help_empire.push("");
@@ -2233,7 +2230,7 @@
 				delete r.structures;
 			});
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Deleted deprecated Memory objects.`;
+			return `[Console] Deleted deprecated Memory objects.`;
 		};
 
 		help_empire.push("empire.highway_mining(rmColony, targetRoom, resourceType, [listRoute], [listSpawnAssistRooms], {customPopulation})");
@@ -2241,12 +2238,12 @@
 		help_empire.push(" - Deploys single extractor to harvest commodity in target room (auto-returns when full)");
 		empire.highway_mining = function (rmColony, targetRoom, resourceType, listRoute, listSpawnAssistRooms, customPopulation) {
 			if (rmColony == null || targetRoom == null || resourceType == null)
-				return `<font color=\"#D3FFA3\">[Console]</font> Error, invalid entry for highway_mining(). Required: colony room, target room, resource type.`;
+				return `[Console] Error, invalid entry for highway_mining(). Required: colony room, target room, resource type.`;
 
 			// Validate resource type
 			let validResources = ['power', 'silicon', 'metal', 'biomass', 'mist'];
 			if (!validResources.includes(resourceType)) {
-				return `<font color=\"#D3FFA3\">[Console]</font> Error, invalid resource type. Valid types: ${validResources.join(', ')}`;
+				return `[Console] Error, invalid resource type. Valid types: ${validResources.join(', ')}`;
 			}
 
 			// Generate unique ID for this highway mining operation (no resourceId)
@@ -2268,7 +2265,7 @@
 			let message = resourceType === "power" 
 				? `Highway power mining operation created for ${resourceType} in ${targetRoom}. Deploys attackers, healers, and carriers. To cancel, delete the entry.`
 				: `Highway commodity mining operation created for ${resourceType} in ${targetRoom}. Single extractor will auto-return when full. To cancel, delete the entry.`;
-			return `<font color=\"#D3FFA3\">[Console]</font> ${message}`;
+			return `[Console] ${message}`;
 		};
 
 		help_empire.push("empire.highway_status()");
@@ -2297,7 +2294,7 @@
 		help_empire.push("empire.highway_cleanup()");
 		empire.highway_cleanup = function () {
 			let highwayMining = Memory.sites.highway_mining;
-			if (!highwayMining) return `<font color=\"#D3FFA3\">[Console]</font> No highway mining operations found.`;
+			if (!highwayMining) return `[Console] No highway mining operations found.`;
 
 			let cleaned = 0;
 			_.each(highwayMining, (data, highwayId) => {
@@ -2307,14 +2304,14 @@
 				}
 			});
 			
-			return `<font color=\"#D3FFA3\">[Console]</font> Cleaned up ${cleaned} completed highway mining operations.`;
+			return `[Console] Cleaned up ${cleaned} completed highway mining operations.`;
 		};
 
 		help_empire.push("empire.highway_reset(highwayId)");
 		empire.highway_reset = function (highwayId) {
 			let highwayMining = Memory.sites.highway_mining;
 			if (!highwayMining || !highwayMining[highwayId]) {
-				return `<font color=\"#D3FFA3\">[Console]</font> Highway operation ${highwayId} not found.`;
+				return `[Console] Highway operation ${highwayId} not found.`;
 			}
 
 			let data = highwayMining[highwayId];
@@ -2333,7 +2330,7 @@
 				delete c.memory.task;
 			});
 			
-			return `<font color=\"#D3FFA3\">[Console]</font> Reset highway operation ${highwayId}. Creeps will re-discover resources.`;
+			return `[Console] Reset highway operation ${highwayId}. Creeps will re-discover resources.`;
 		};
 
 
@@ -2344,7 +2341,7 @@
 		path.road = function (rmName, startX, startY, endX, endY) {
 			let room = Game.rooms[rmName];
 			if (room == null)
-				return `<font color=\"#D3FFA3\">[Console]</font> Error, ${rmName} not found.`;
+				return `[Console] Error, ${rmName} not found.`;
 
 			let from = new RoomPosition(startX, startY, rmName);
 			let to = new RoomPosition(endX, endY, rmName);
@@ -2354,7 +2351,7 @@
 			room.createConstructionSite(startX, startY, "road");
 			room.createConstructionSite(endX, endY, "road");
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Construction sites placed in ${rmName} for road from (${startX}, ${startY}) to (${endX}, ${endY}).`;
+			return `[Console] Construction sites placed in ${rmName} for road from (${startX}, ${startY}) to (${endX}, ${endY}).`;
 		};
 
 		help_path.push("path.exit_tile(exit_pos)");
@@ -2362,13 +2359,13 @@
 		path.exit_tile = function (exit_pos) {
 			// Specifies preferred exit tiles to assist inter-room pathfinding
 			if (!(exit_pos.x == 0 || exit_pos.x == 49 || exit_pos.y == 0 || exit_pos.y == 49)) {
-				return `<font color=\"#D3FFA3\">[Console]</font> Invalid preferred exit tile position; must be an exit tile!`;
+				return `[Console] Invalid preferred exit tile position; must be an exit tile!`;
 			}
 
 			if (_.get(Memory, ["hive", "paths", "exits", "rooms", exit_pos.roomName]) == null)
 				_.set(Memory, ["hive", "paths", "exits", "rooms", exit_pos.roomName], new Array());
 			Memory["hive"]["paths"]["exits"]["rooms"][exit_pos.roomName].push(exit_pos);
-			return `<font color=\"#D3FFA3\">[Console]</font> Preferred exit tile position added to Memory.hive.paths.exits.rooms.${exit_pos.roomName}`;
+			return `[Console] Preferred exit tile position added to Memory.hive.paths.exits.rooms.${exit_pos.roomName}`;
 		};
 
 		help_path.push("path.exit_area(roomName, startX, startY, endX, endY)");
@@ -2380,7 +2377,7 @@
 				}
 			}
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Preferred exit tile position added to Memory.hive.paths.exits.rooms.${room_name}`;
+			return `[Console] Preferred exit tile position added to Memory.hive.paths.exits.rooms.${room_name}`;
 		};
 
 		help_path.push("path.prefer(prefer_pos)");
@@ -2390,7 +2387,7 @@
 			if (_.get(Memory, ["hive", "paths", "prefer", "rooms", prefer_pos.roomName]) == null)
 				_.set(Memory, ["hive", "paths", "prefer", "rooms", prefer_pos.roomName], new Array());
 			Memory["hive"]["paths"]["prefer"]["rooms"][prefer_pos.roomName].push(prefer_pos);
-			return `<font color=\"#D3FFA3\">[Console]</font> Preference position added to Memory.hive.paths.prefer.rooms.${prefer_pos.roomName}`;
+			return `[Console] Preference position added to Memory.hive.paths.prefer.rooms.${prefer_pos.roomName}`;
 		};
 
 		help_path.push("path.prefer_area(roomName, startX, startY, endX, endY)");
@@ -2405,7 +2402,7 @@
 				}
 			}
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Preference positions added to Memory.hive.paths.prefer.rooms.${room_name}`;
+			return `[Console] Preference positions added to Memory.hive.paths.prefer.rooms.${room_name}`;
 		};
 
 		help_path.push("path.avoid(avoid_pos)");
@@ -2414,7 +2411,7 @@
 			if (_.get(Memory, ["hive", "paths", "avoid", "rooms", avoid_pos.roomName]) == null)
 				_.set(Memory, ["hive", "paths", "avoid", "rooms", avoid_pos.roomName], new Array());
 			Memory["hive"]["paths"]["avoid"]["rooms"][avoid_pos.roomName].push(avoid_pos);
-			return `<font color=\"#D3FFA3\">[Console]</font> Avoid position added to Memory.hive.paths.avoid.rooms.${avoid_pos.roomName}`;
+			return `[Console] Avoid position added to Memory.hive.paths.avoid.rooms.${avoid_pos.roomName}`;
 		};
 
 		help_path.push("path.avoid_area(roomName, startX, startY, endX, endY)");
@@ -2429,7 +2426,7 @@
 				}
 			}
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Avoid positions added to Memory.hive.paths.avoid.rooms.${room_name}`;
+			return `[Console] Avoid positions added to Memory.hive.paths.avoid.rooms.${room_name}`;
 		};
 
 		help_path.push("path.avoid_radius(roomName, centerX, centerY, radius)");
@@ -2444,7 +2441,7 @@
 				}
 			}
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Avoid positions added to Memory.hive.paths.avoid.rooms.${room_name}`;
+			return `[Console] Avoid positions added to Memory.hive.paths.avoid.rooms.${room_name}`;
 		};
 
 		help_path.push("path.reset(roomName)");
@@ -2453,7 +2450,7 @@
 			delete Memory["hive"]["paths"]["avoid"]["rooms"][room_name];
 			delete Memory["hive"]["paths"]["prefer"]["rooms"][room_name];
 			delete Memory["hive"]["paths"]["exits"]["rooms"][room_name];
-			return `<font color=\"#D3FFA3\">[Console]</font> Path modifiers reset for ${room_name}`;
+			return `[Console] Path modifiers reset for ${room_name}`;
 		};
 
 
@@ -2466,7 +2463,7 @@
 			else
 				_.set(Memory, ["hive", "visuals", "show_path"], true)
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Visuals for paths toggled to be shown: ${_.get(Memory, ["hive", "visuals", "show_path"], false)}`;
+			return `[Console] Visuals for paths toggled to be shown: ${_.get(Memory, ["hive", "visuals", "show_path"], false)}`;
 		};
 
 		help_visuals.push("visuals.toggle_repair()");
@@ -2477,7 +2474,7 @@
 			else
 				_.set(Memory, ["hive", "visuals", "show_repair"], true)
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Visuals for repairs toggled to be shown: ${_.get(Memory, ["hive", "visuals", "show_repair"], false)}`;
+			return `[Console] Visuals for repairs toggled to be shown: ${_.get(Memory, ["hive", "visuals", "show_repair"], false)}`;
 		};
 
 		help_visuals.push("visuals.toggle_speech()");
@@ -2487,7 +2484,7 @@
 			else
 				_.set(Memory, ["hive", "visuals", "show_speech"], true)
 
-			return `<font color=\"#D3FFA3\">[Console]</font> Visuals for speech toggled to be shown: ${_.get(Memory, ["hive", "visuals", "show_speech"], false)}`;
+			return `[Console] Visuals for speech toggled to be shown: ${_.get(Memory, ["hive", "visuals", "show_speech"], false)}`;
 		};
 
 		help_visuals.push("visuals.set_performance(ticks)");
@@ -2499,7 +2496,7 @@
 			if (ticks < 1) ticks = 1;
 			if (ticks > 50) ticks = 50;
 			_.set(Memory, ["hive", "visuals", "update_interval"], ticks);
-			return `<font color=\"#D3FFA3\">[Console]</font> Visual performance set to update every ${ticks} ticks.`;
+			return `[Console] Visual performance set to update every ${ticks} ticks.`;
 		};
 
 		help_visuals.push("visuals.get_performance()");
@@ -2511,12 +2508,12 @@
 			const cpuLimit = Game.cpu.limit;
 			const cpuPercent = (cpuUsed / cpuLimit * 100).toFixed(1);
 			
-			console.log(`<font color=\"#D3FFA3\">[Visuals]</font> <b>Performance Settings:</b>`);
+			console.log(`[Visuals] Performance Settings:`);
 			console.log(`  Update Interval: ${interval} ticks`);
 			console.log(`  Current CPU: ${cpuUsed.toFixed(2)}/${cpuLimit} (${cpuPercent}%)`);
 			console.log(`  Status: ${cpuPercent > 80 ? "⚠️ High" : cpuPercent > 60 ? "⚡ Medium" : "✅ Good"}`);
 			
-			return `<font color=\"#D3FFA3\">[Console]</font> Visual performance status displayed.`;
+			return `[Console] Visual performance status displayed.`;
 		};
 
 		help_visuals.push("visuals.clear_cache()");
@@ -2532,20 +2529,20 @@
 					cacheDuration: 5
 				};
 			}
-			return `<font color=\"#D3FFA3\">[Console]</font> Visual cache cleared.`;
+			return `[Console] Visual cache cleared.`;
 		};
 		pause = new Object();
 
 		help_pause.push("pause.mineral_extraction()")
 		pause.mineral_extraction = function () {
 			_.set(Memory, ["hive", "pause", "extracting"], true);
-			return `<font color=\"#D3FFA3\">[Console]</font> Pausing mineral extraction- delete Memory.hive.pause.extracting to resume.`;
+			return `[Console] Pausing mineral extraction- delete Memory.hive.pause.extracting to resume.`;
 		};
 
 		help_pause.push("pause.refill_bucket()")
 		pause.refill_bucket = function () {
 			_.set(Memory, ["hive", "pause", "bucket"], true);
-			return `<font color=\"#D3FFA3\">[Console]</font> Pausing main.js to refill bucket.`;
+			return `[Console] Pausing main.js to refill bucket.`;
 		};
 
 
@@ -2570,15 +2567,15 @@
 			let cellStyle = "style=\"border: 1px solid #666; padding: 8px 12px; text-align: left;\"";
 			let headerStyle = "style=\"border: 1px solid #666; padding: 8px 12px; text-align: left; background-color: #444; color: #FFD700; font-weight: bold;\"";
 			
-			console.log(`<font color=\"#FFD700\">[Pixels]</font> <b>Pixel Generation Status:</b>`);
+			console.log(`[Pixels] Pixel Generation Status:`);
 			
-			let statusTable = `<table ${tableStyle}>`;
-			statusTable += `<tr><th ${headerStyle}>Setting</th><th ${headerStyle}>Value</th><th ${headerStyle}>Status</th></tr>`;
-			statusTable += `<tr><td ${cellStyle}>Enabled</td><td ${cellStyle}>${enabled}</td><td ${cellStyle}>${enabled ? "<font color=\"#47FF3E\">✓ Active</font>" : "<font color=\"#FF6B6B\">✗ Disabled</font>"}</td></tr>`;
-			statusTable += `<tr><td ${cellStyle}>CPU Threshold</td><td ${cellStyle}>${(cpuThreshold * 100).toFixed(0)}%</td><td ${cellStyle}>${cpuPercent < (cpuThreshold * 100) ? "<font color=\"#47FF3E\">✓ Below</font>" : "<font color=\"#FFA500\">⚠ Above</font>"}</td></tr>`;
-			statusTable += `<tr><td ${cellStyle}>Current CPU</td><td ${cellStyle}>${cpuPercent}%</td><td ${cellStyle}>${cpuUsed.toFixed(2)}/${cpuLimit}</td></tr>`;
-			statusTable += `<tr><td ${cellStyle}>CPU Bucket</td><td ${cellStyle}>${bucket}</td><td ${cellStyle}>${bucket >= 10000 ? "<font color=\"#47FF3E\">✓ Full</font>" : "<font color=\"#FFA500\">⚠ " + bucket + "/10000</font>"}</td></tr>`;
-			statusTable += `</table>`;
+			let statusTable = ``;
+			statusTable += `	Setting		Value		Status	`;
+			statusTable += `	Enabled		${enabled}		${enabled ? "✓ Active" : "✗ Disabled"}	`;
+			statusTable += `	CPU Threshold		${(cpuThreshold * 100).toFixed(0)}%		${cpuPercent < (cpuThreshold * 100) ? "✓ Below" : "⚠ Above"}	`;
+			statusTable += `	Current CPU		${cpuPercent}%		${cpuUsed.toFixed(2)}/${cpuLimit}	`;
+			statusTable += `	CPU Bucket		${bucket}		${bucket >= 10000 ? "✓ Full" : "⚠ " + bucket + "/10000"}	`;
+			statusTable += ``;
 			console.log(statusTable);
 			
 			if (stats) {
@@ -2598,31 +2595,31 @@
 				
 				let timeSinceLastPixel = lastGenerated > 0 ? (Game.time - lastGenerated) : "Never";
 				
-				console.log(`<font color=\"#FFD700\">[Pixels]</font> <b>Statistics:</b>`);
-				let statsTable = `<table ${tableStyle}>`;
-				statsTable += `<tr><th ${headerStyle}>Metric</th><th ${headerStyle}>Value</th></tr>`;
-				statsTable += `<tr><td ${cellStyle}>Total Pixels Generated</td><td ${cellStyle}>${totalGenerated}</td></tr>`;
-				statsTable += `<tr><td ${cellStyle}>Last Generated</td><td ${cellStyle}>${lastGenerated > 0 ? "Tick " + lastGenerated : "Never"}</td></tr>`;
-				statsTable += `<tr><td ${cellStyle}>Time Since Last Pixel</td><td ${cellStyle}>${timeSinceLastPixel !== "Never" ? timeSinceLastPixel + " ticks ago" : "Never"}</td></tr>`;
-				statsTable += `<tr><td ${cellStyle}>Generation Rate</td><td ${cellStyle}>${generationRate}</td></tr>`;
-				statsTable += `</table>`;
+				console.log(`[Pixels] Statistics:`);
+				let statsTable = ``;
+				statsTable += `	Metric		Value	`;
+				statsTable += `	Total Pixels Generated		${totalGenerated}	`;
+				statsTable += `	Last Generated		${lastGenerated > 0 ? "Tick " + lastGenerated : "Never"}	`;
+				statsTable += `	Time Since Last Pixel		${timeSinceLastPixel !== "Never" ? timeSinceLastPixel + " ticks ago" : "Never"}	`;
+				statsTable += `	Generation Rate		${generationRate}	`;
+				statsTable += ``;
 				console.log(statsTable);
 			} else {
-				console.log(`<font color=\"#FFD700\">[Pixels]</font> <b>Statistics:</b> No pixels generated yet.`);
+				console.log(`[Pixels] Statistics: No pixels generated yet.`);
 			}
 			
 			// Recommendation
 			if (enabled && bucket >= 10000 && cpuPercent >= (cpuThreshold * 100)) {
-				console.log(`<font color=\"#FFA500\">[Pixels]</font> <b>⚠ Recommendation:</b> CPU usage (${cpuPercent}%) is above threshold (${(cpuThreshold * 100).toFixed(0)}%). Pixels will not generate until CPU usage decreases. Consider increasing threshold with pixels.set_threshold().`);
+				console.log(`[Pixels] ⚠ Recommendation: CPU usage (${cpuPercent}%) is above threshold (${(cpuThreshold * 100).toFixed(0)}%). Pixels will not generate until CPU usage decreases. Consider increasing threshold with pixels.set_threshold().`);
 			} else if (!enabled) {
-				console.log(`<font color=\"#FFA500\">[Pixels]</font> <b>Note:</b> Pixel generation is disabled. Use pixels.enable() to start generating.`);
+				console.log(`[Pixels] Note: Pixel generation is disabled. Use pixels.enable() to start generating.`);
 			} else if (bucket < 10000) {
-				console.log(`<font color=\"#FFA500\">[Pixels]</font> <b>Note:</b> Bucket must be full (10,000) to generate pixels. Current: ${bucket}.`);
+				console.log(`[Pixels] Note: Bucket must be full (10,000) to generate pixels. Current: ${bucket}.`);
 			} else {
-				console.log(`<font color=\"#47FF3E\">[Pixels]</font> <b>✓ Status:</b> All conditions met for pixel generation!`);
+				console.log(`[Pixels] ✓ Status: All conditions met for pixel generation!`);
 			}
 			
-			return `<font color=\"#FFD700\">[Pixels]</font> Pixel status displayed.`;
+			return `[Pixels] Pixel status displayed.`;
 		};
 
 		help_pixels.push("pixels.enable()");
@@ -2630,7 +2627,7 @@
 
 		pixels.enable = function () {
 			_.set(Memory, ["hive", "pixels", "enabled"], true);
-			return `<font color=\"#FFD700\">[Pixels]</font> Pixel generation enabled.`;
+			return `[Pixels] Pixel generation enabled.`;
 		};
 
 		help_pixels.push("pixels.disable()");
@@ -2638,7 +2635,7 @@
 
 		pixels.disable = function () {
 			_.set(Memory, ["hive", "pixels", "enabled"], false);
-			return `<font color=\"#FFD700\">[Pixels]</font> Pixel generation disabled.`;
+			return `[Pixels] Pixel generation disabled.`;
 		};
 
 		help_pixels.push("pixels.set_threshold(percent)");
@@ -2649,10 +2646,10 @@
 
 		pixels.set_threshold = function (percent) {
 			if (percent == null || percent < 0 || percent > 100) {
-				return `<font color=\"#FF6B6B\">[Pixels]</font> Error: Threshold must be between 0 and 100.`;
+				return `[Pixels] Error: Threshold must be between 0 and 100.`;
 			}
 			_.set(Memory, ["hive", "pixels", "cpu_threshold"], percent / 100);
-			return `<font color=\"#FFD700\">[Pixels]</font> CPU threshold set to ${percent}%. Pixels will only generate when CPU usage is below this level.`;
+			return `[Pixels] CPU threshold set to ${percent}%. Pixels will only generate when CPU usage is below this level.`;
 		};
 
 		help_pixels.push("pixels.reset_stats()");
@@ -2664,7 +2661,7 @@
 				last_generated: 0,
 				generation_history: []
 			});
-			return `<font color=\"#FFD700\">[Pixels]</font> Pixel statistics reset.`;
+			return `[Pixels] Pixel statistics reset.`;
 		};
 
 		shards = new Object();
@@ -2672,14 +2669,14 @@
 		help_shards.push("shards.help()");
 		help_shards.push(" - Print a quick reference to shard commands");
 		shards.help = function () {
-			return `<font color=\"#4ECDC4\">[Shards]</font> Commands: shards.status(), shards.requests(), shards.global(), shards.set_primary(). Use help("shards") for full descriptions.`;
+			return `[Shards] Commands: shards.status(), shards.requests(), shards.global(), shards.set_primary(). Use help("shards") for full descriptions.`;
 		};
 
 		help_shards.push("shards.status(shardName?)");
 		help_shards.push(" - Show local shard pulse and remote shard summaries (optional shardName)");
 		shards.status = function (targetShard) {
 			if (typeof ShardMemory === "undefined") {
-				return `<font color="#FF6B6B">[Shards]</font> Inter-shard interface not initialized.`;
+				return `[Shards] Inter-shard interface not initialized.`;
 			}
 
 			let payload = ShardMemory.getLocalPayload();
@@ -2687,7 +2684,7 @@
 			let primaryShard = ShardMemory.getPrimaryShardName();
 
 			let lines = new Array();
-			lines.push(`<font color="#4ECDC4">[Shards]</font> Local shard <b>${Game.shard.name}</b> (${role})`);
+			lines.push(`[Shards] Local shard ${Game.shard.name} (${role})`);
 			lines.push(`  Primary shard: ${primaryShard}`);
 			lines.push(`  Heartbeat: ${payload.heartbeat} (summary tick ${_.get(payload, ["summary", "tick"], "n/a")})`);
 			lines.push(`  Local globals: ${_.size(_.get(payload, ["global", "creeps"], {}))}`);
@@ -2734,7 +2731,7 @@
 		help_shards.push(" - Inspect pending inter-shard requests (resource|creep|mission)");
 		shards.requests = function (type) {
 			if (typeof ShardMemory === "undefined") {
-				return `<font color="#FF6B6B">[Shards]</font> Inter-shard interface not initialized.`;
+				return `[Shards] Inter-shard interface not initialized.`;
 			}
 
 			let validTypes = ["resource", "creep", "mission"];
@@ -2742,7 +2739,7 @@
 			if (type != null) {
 				type = type.toString().toLowerCase();
 				if (!_.includes(validTypes, type)) {
-					return `<font color="#FF6B6B">[Shards]</font> Unknown request type "${type}". Use resource, creep, or mission.`;
+					return `[Shards] Unknown request type "${type}". Use resource, creep, or mission.`;
 				}
 				filters = [type];
 			}
@@ -2750,7 +2747,7 @@
 			let lines = new Array();
 			if (ShardMemory.isPrimaryShard()) {
 				let snapshot = _.get(Memory, ["hive", "ism", "primary_snapshot", "requests"]);
-				lines.push(`<font color="#4ECDC4">[Shards]</font> Aggregated remote requests (primary view)`);
+				lines.push(`[Shards] Aggregated remote requests (primary view)`);
 				if (!snapshot) {
 					lines.push("  No requests recorded yet.");
 				} else {
@@ -2767,7 +2764,7 @@
 				}
 			} else {
 				let payload = ShardMemory.getLocalPayload();
-				lines.push(`<font color="#4ECDC4">[Shards]</font> Local outbound requests`);
+				lines.push(`[Shards] Local outbound requests`);
 				_.each(filters, queue => {
 					let items = _.get(payload, ["queues", queue], []);
 					lines.push(`  ${queue}: ${items.length} queued`);
@@ -2786,7 +2783,7 @@
 		help_shards.push(" - List known global creeps or inspect a specific creep");
 		shards.global = function (creepName) {
 			if (typeof ShardMemory === "undefined") {
-				return `<font color="#FF6B6B">[Shards]</font> Inter-shard interface not initialized.`;
+				return `[Shards] Inter-shard interface not initialized.`;
 			}
 
 			let manifest = {};
@@ -2810,14 +2807,14 @@
 			if (creepName != null) {
 				let info = manifest[creepName];
 				if (!info) {
-					return `<font color="#FF6B6B">[Shards]</font> Global creep ${creepName} not found.`;
+					return `[Shards] Global creep ${creepName} not found.`;
 				}
-				return `<font color="#4ECDC4">[Shards]</font> ${creepName}\n${JSON.stringify(info, null, 2)}`;
+				return `[Shards] ${creepName}\n${JSON.stringify(info, null, 2)}`;
 			}
 
 			let entries = Object.entries(manifest);
 			let lines = new Array();
-			lines.push(`<font color="#4ECDC4">[Shards]</font> Known global creeps: ${entries.length}`);
+			lines.push(`[Shards] Known global creeps: ${entries.length}`);
 
 			if (entries.length === 0) {
 				return lines.join("\n");
@@ -2838,13 +2835,13 @@
 		help_shards.push(" - Update the designated primary shard (defaults to shard0)");
 		shards.set_primary = function (shardName) {
 			if (!_.isString(shardName) || shardName.length === 0) {
-				return `<font color="#FF6B6B">[Shards]</font> Provide a shard name, e.g. shards.set_primary('shard0').`;
+				return `[Shards] Provide a shard name, e.g. shards.set_primary('shard0').`;
 			}
 			if (typeof ShardMemory === "undefined") {
-				return `<font color="#FF6B6B">[Shards]</font> Inter-shard interface not initialized.`;
+				return `[Shards] Inter-shard interface not initialized.`;
 			}
 			ShardMemory.setPrimaryShardName(shardName);
-			return `<font color="#4ECDC4">[Shards]</font> Primary shard set to ${shardName}.`;
+			return `[Shards] Primary shard set to ${shardName}.`;
 		};
 
 		// Primary-shard mission registry commands (Option A)
@@ -2852,65 +2849,65 @@
 		help_shards.push(" - Inspect the authoritative mission for a creep (primary shard)");
 		shards.mission = function (creepName) {
 			if (!creepName)
-				return `<font color="#FF6B6B">[Shards]</font> Provide a creep name: shards.mission('MyCreep')`;
+				return `[Shards] Provide a creep name: shards.mission('MyCreep')`;
 			if (typeof ShardMemory === "undefined")
-				return `<font color="#FF6B6B">[Shards]</font> Inter-shard interface not initialized.`;
+				return `[Shards] Inter-shard interface not initialized.`;
 			var mission = ShardMemory.getMission(creepName);
 			if (!mission)
-				return `<font color="#FF944E">[Shards]</font> No mission found for ${creepName} on primary.`;
-			console.log(`<font color="#4ECDC4">[Shards]</font> Mission for ${creepName}:\n` + JSON.stringify(mission, null, 2));
-			return `<font color="#4ECDC4">[Shards]</font> Mission displayed for ${creepName}.`;
+				return `[Shards] No mission found for ${creepName} on primary.`;
+			console.log(`[Shards] Mission for ${creepName}:\n` + JSON.stringify(mission, null, 2));
+			return `[Shards] Mission displayed for ${creepName}.`;
 		};
 
 		help_shards.push("shards.missions(limit?)");
 		help_shards.push(" - List missions registered on the primary shard (default limit 12)");
 		shards.missions = function (limit) {
 			if (typeof ShardMemory === "undefined")
-				return `<font color="#FF6B6B">[Shards]</font> Inter-shard interface not initialized.`;
+				return `[Shards] Inter-shard interface not initialized.`;
 			var primary = ShardMemory.readPrimary();
 			if (!primary)
-				return `<font color="#FF944E">[Shards]</font> No primary payload available.`;
+				return `[Shards] No primary payload available.`;
 			var missions = _.get(primary, "missions", {});
 			var names = Object.keys(missions);
 			var max = parseInt(limit) || 12;
-			console.log(`<font color="#4ECDC4">[Shards]</font> Missions on primary: ${names.length}`);
+			console.log(`[Shards] Missions on primary: ${names.length}`);
 			_.each(_.take(names, max), function (name) {
 				var m = missions[name] || {};
 				console.log(`  ${name}: role=${_.get(m, 'role', 'unknown')} mission=${_.get(m, 'mission', 'unknown')} shard=${_.get(m, 'current_shard', _.get(m, ['origin','shard'], 'n/a'))} updated=${_.get(m, 'updated', 'n/a')}`);
 			});
 			if (names.length > max)
 				console.log(`  ... ${names.length - max} more`);
-			return `<font color="#4ECDC4">[Shards]</font> Listed ${Math.min(names.length, max)} mission(s).`;
+			return `[Shards] Listed ${Math.min(names.length, max)} mission(s).`;
 		};
 
 		help_shards.push("shards.set_mission(creepName, mission)");
 		help_shards.push(" - Set/replace the authoritative mission for a creep (primary only)");
 		shards.set_mission = function (creepName, mission) {
 			if (!creepName || typeof mission !== "object")
-				return `<font color="#FF6B6B">[Shards]</font> Usage: shards.set_mission('MyCreep', { role: 'worker', mission: 'assist', origin: { shard: 'shard0', room: 'E1N1' } })`;
+				return `[Shards] Usage: shards.set_mission('MyCreep', { role: 'worker', mission: 'assist', origin: { shard: 'shard0', room: 'E1N1' } })`;
 			if (typeof ShardMemory === "undefined")
-				return `<font color="#FF6B6B">[Shards]</font> Inter-shard interface not initialized.`;
+				return `[Shards] Inter-shard interface not initialized.`;
 			if (!ShardMemory.isPrimaryShard()) {
-				console.log(`<font color="#FF944E">[Shards]</font> Warning: set_mission should be run on the primary shard (${ShardMemory.getPrimaryShardName()}).`);
+				console.log(`[Shards] Warning: set_mission should be run on the primary shard (${ShardMemory.getPrimaryShardName()}).`);
 			}
 			// Minimal normalization
 			mission = _.assign({}, mission, { updated: Game.time });
 			ShardMemory.registerMission(creepName, mission);
-			return `<font color="#4ECDC4">[Shards]</font> Mission registered for ${creepName}.`;
+			return `[Shards] Mission registered for ${creepName}.`;
 		};
 
 		help_shards.push("shards.remove_mission(creepName)");
 		help_shards.push(" - Remove the mission entry for a creep (primary only)");
 		shards.remove_mission = function (creepName) {
 			if (!creepName)
-				return `<font color="#FF6B6B">[Shards]</font> Provide a creep name: shards.remove_mission('MyCreep')`;
+				return `[Shards] Provide a creep name: shards.remove_mission('MyCreep')`;
 			if (typeof ShardMemory === "undefined")
-				return `<font color="#FF6B6B">[Shards]</font> Inter-shard interface not initialized.`;
+				return `[Shards] Inter-shard interface not initialized.`;
 			if (!ShardMemory.isPrimaryShard()) {
-				console.log(`<font color="#FF944E">[Shards]</font> Warning: remove_mission should be run on the primary shard (${ShardMemory.getPrimaryShardName()}).`);
+				console.log(`[Shards] Warning: remove_mission should be run on the primary shard (${ShardMemory.getPrimaryShardName()}).`);
 			}
 			ShardMemory.removeMission(creepName);
-			return `<font color="#4ECDC4">[Shards]</font> Mission removed for ${creepName}.`;
+			return `[Shards] Mission removed for ${creepName}.`;
 		};
 
 		// Scout mission diagnostics
@@ -2920,7 +2917,7 @@
 		help_scouts.push(" - Displays active scouts, patrol state, shard locations, and mission details");
 		scouts.status = function (requestId) {
 			if (typeof Control === "undefined") {
-				return `<font color="#FF6B6B">[Scouts]</font> Control system not initialized.`;
+				return `[Scouts] Control system not initialized.`;
 			}
 
 			let allRequests = {};
@@ -2947,11 +2944,11 @@
 			}
 
 			if (requestId && Object.keys(allRequests).length === 0) {
-				return `<font color="#FF944E">[Scouts]</font> No scout request found with ID: ${requestId}`;
+				return `[Scouts] No scout request found with ID: ${requestId}`;
 			}
 
 			let lines = [];
-			lines.push(`<font color="#4ECDC4"><b>[Scouts]</b></font> Scout Mission Status (Tick ${Game.time})`);
+			lines.push(`[Scouts] Scout Mission Status (Tick ${Game.time})`);
 			lines.push("");
 
 			for (let reqId in allRequests) {
@@ -2959,7 +2956,7 @@
 				let req = reqData.request;
 				let colony = reqData.colony;
 
-				lines.push(`<font color="#D3FFA3"><b>Request ID:</b></font> ${reqId}`);
+				lines.push(`Request ID: ${reqId}`);
 				lines.push(`  Colony: ${colony}`);
 				lines.push(`  Patrol Mode: ${req.patrol_mode || "station"}`);
 				lines.push(`  Count: ${req.count || 1} (Active: ${req.active || 0}, Remote: ${req.remote_count || 0})`);
@@ -2990,7 +2987,7 @@
 							let ttl = creep.ticksToLive;
 							lines.push(`    - ${creepName}: ${room} [${shard}], state=${patrolState}, TTL=${ttl}`);
 						} else {
-							lines.push(`    - ${creepName}: <font color="#FF944E">not found</font>`);
+							lines.push(`    - ${creepName}: not found`);
 						}
 					}
 				}
@@ -3005,7 +3002,7 @@
 						let creepName = remoteNames[i];
 						let lastSeen = remoteCreeps[creepName];
 						let isAlive = Control.isCreepTrackedGlobally(creepName, globalState);
-						let status = isAlive ? "alive" : "<font color=\"#FF944E\">dead</font>";
+						let status = isAlive ? "alive" : "dead";
 						lines.push(`    - ${creepName}: ${status}, last seen ${Game.time - lastSeen} ticks ago`);
 					}
 				}
@@ -3017,8 +3014,8 @@
 				lines.push("No active scout requests found.");
 			}
 
-			console.log(lines.join("<br>"));
-			return `<font color="#4ECDC4">[Scouts]</font> Status displayed for ${Object.keys(allRequests).length} request(s).`;
+			console.log(lines.join("\n"));
+			return `[Scouts] Status displayed for ${Object.keys(allRequests).length} request(s).`;
 		};
 
 		help_scouts.push("scouts.debug(level)");
@@ -3028,15 +3025,15 @@
 		scouts.debug = function (level) {
 			if (level === undefined || level === null) {
 				let currentLevel = _.get(Memory, ["hive", "debug", "scout"], 0);
-				return `<font color="#4ECDC4">[Scouts]</font> Current debug level: ${currentLevel} (0=none, 1=errors, 2=movement, 3=verbose)`;
+				return `[Scouts] Current debug level: ${currentLevel} (0=none, 1=errors, 2=movement, 3=verbose)`;
 			}
 			level = parseInt(level);
 			if (isNaN(level) || level < 0 || level > 3) {
-				return `<font color="#FF944E">[Scouts]</font> Invalid debug level. Use 0-3.`;
+				return `[Scouts] Invalid debug level. Use 0-3.`;
 			}
 			_.set(Memory, ["hive", "debug", "scout"], level);
 			let levelNames = ["none", "errors/state", "movement/portals", "verbose"];
-			return `<font color="#4ECDC4">[Scouts]</font> Debug level set to ${level} (${levelNames[level]}).`;
+			return `[Scouts] Debug level set to ${level} (${levelNames[level]}).`;
 		};
 
 		help_scouts.push("scouts.trace(creepName)");
@@ -3044,18 +3041,18 @@
 		help_scouts.push(" - Displays current state, memory, position, and mission details");
 		scouts.trace = function (creepName) {
 			if (!creepName) {
-				return `<font color="#FF944E">[Scouts]</font> Please provide a creep name.`;
+				return `[Scouts] Please provide a creep name.`;
 			}
 			let creep = Game.creeps[creepName];
 			if (!creep) {
-				return `<font color="#FF944E">[Scouts]</font> Creep ${creepName} not found.`;
+				return `[Scouts] Creep ${creepName} not found.`;
 			}
 			if (creep.memory.role !== "scout") {
-				return `<font color="#FF944E">[Scouts]</font> ${creepName} is not a scout.`;
+				return `[Scouts] ${creepName} is not a scout.`;
 			}
 
 			let output = [];
-			output.push(`<font color="#4ECDC4">[Scouts]</font> <b>Trace for ${creepName}:</b>`);
+			output.push(`[Scouts] Trace for ${creepName}:`);
 			output.push(`Position: ${creep.pos.x},${creep.pos.y} in ${creep.room.name} (shard: ${Game.shard.name})`);
 			output.push(`TTL: ${creep.ticksToLive}`);
 			output.push(`Role: ${creep.memory.role}`);
@@ -3082,8 +3079,8 @@
 				output.push(`Path Destination: ${pathDest.roomName} (${pathDest.x},${pathDest.y})`);
 			}
 
-			console.log(output.join("<br>"));
-			return `<font color="#4ECDC4">[Scouts]</font> Trace complete for ${creepName}.`;
+			console.log(output.join("\n"));
+			return `[Scouts] Trace complete for ${creepName}.`;
 		};
 
 		help_scouts.push("scouts.state(creepName)");
@@ -3091,14 +3088,14 @@
 		help_scouts.push(" - Compact version of trace() focused on state information");
 		scouts.state = function (creepName) {
 			if (!creepName) {
-				return `<font color="#FF944E">[Scouts]</font> Please provide a creep name.`;
+				return `[Scouts] Please provide a creep name.`;
 			}
 			let creep = Game.creeps[creepName];
 			if (!creep) {
-				return `<font color="#FF944E">[Scouts]</font> Creep ${creepName} not found.`;
+				return `[Scouts] Creep ${creepName} not found.`;
 			}
 			if (creep.memory.role !== "scout") {
-				return `<font color="#FF944E">[Scouts]</font> ${creepName} is not a scout.`;
+				return `[Scouts] ${creepName} is not a scout.`;
 			}
 
 			let state = {
@@ -3112,7 +3109,7 @@
 				restored: creep.memory._scout_restored || false
 			};
 
-			return `<font color="#4ECDC4">[Scouts]</font> ${creepName} state: ${JSON.stringify(state)}`;
+			return `[Scouts] ${creepName} state: ${JSON.stringify(state)}`;
 		};
 
 		help_scouts.push("scouts.movement(creepName)");
@@ -3120,30 +3117,30 @@
 		help_scouts.push(" - Requires movement tracking to be enabled");
 		scouts.movement = function (creepName) {
 			if (!creepName) {
-				return `<font color="#FF944E">[Scouts]</font> Please provide a creep name.`;
+				return `[Scouts] Please provide a creep name.`;
 			}
 			let creep = Game.creeps[creepName];
 			if (!creep) {
-				return `<font color="#FF944E">[Scouts]</font> Creep ${creepName} not found.`;
+				return `[Scouts] Creep ${creepName} not found.`;
 			}
 			if (creep.memory.role !== "scout") {
-				return `<font color="#FF944E">[Scouts]</font> ${creepName} is not a scout.`;
+				return `[Scouts] ${creepName} is not a scout.`;
 			}
 
 			let history = _.get(creep.memory, "_scout_movement_history", []);
 			if (history.length === 0) {
-				return `<font color="#FF944E">[Scouts]</font> No movement history available for ${creepName}. Movement tracking may not be enabled.`;
+				return `[Scouts] No movement history available for ${creepName}. Movement tracking may not be enabled.`;
 			}
 
 			let output = [];
-			output.push(`<font color="#4ECDC4">[Scouts]</font> <b>Movement history for ${creepName} (last ${Math.min(10, history.length)} ticks):</b>`);
+			output.push(`[Scouts] Movement history for ${creepName} (last ${Math.min(10, history.length)} ticks):`);
 			let recent = history.slice(-10);
 			_.each(recent, (entry, idx) => {
 				output.push(`Tick ${entry.tick}: ${entry.action} at ${entry.pos.x},${entry.pos.y}@${entry.room}`);
 			});
 
-			console.log(output.join("<br>"));
-			return `<font color="#4ECDC4">[Scouts]</font> Movement history displayed for ${creepName}.`;
+			console.log(output.join("\n"));
+			return `[Scouts] Movement history displayed for ${creepName}.`;
 		};
 
 
@@ -3152,7 +3149,7 @@
 	 * *********************************************************** */
 	
 	help_shard = new Array();
-	help_shard.push(`<font color=\"#D3FFA3\"><u>Multi-Shard Commands:</u></font>`);
+	help_shard.push(`Multi-Shard Commands:`);
 	
 	global.shard = new Object();
 	
@@ -3166,7 +3163,7 @@
 			// Show specific shard
 			let status = ShardCoordinator.getShardStatus(shardName);
 			if (!status) {
-				return `<font color=\"#FF0000\">[Shard]</font> Error: Shard ${shardName} not found`;
+				return `[Shard] Error: Shard ${shardName} not found`;
 			}
 			
 			// Display detailed status
@@ -3177,36 +3174,36 @@
 			let tick = status.tick || 0;
 			let age = Game.time - tick;
 			
-			console.log(`<font color=\"#00FFFF\">[Shard]</font> === Shard: ${shardName} ===`);
-			console.log(`<font color=\"#00FFFF\">[Shard]</font> Tick: ${tick} (age: ${age} ticks)`);
-			console.log(`<font color=\"#00FFFF\">[Shard]</font> Colonies: ${colonies}`);
-			console.log(`<font color=\"#00FFFF\">[Shard]</font> Energy: ${energy.toLocaleString()}`);
-			console.log(`<font color=\"#00FFFF\">[Shard]</font> CPU: ${cpu.toFixed(1)} / Bucket: ${bucket}`);
+			console.log(`[Shard] === Shard: ${shardName} ===`);
+			console.log(`[Shard] Tick: ${tick} (age: ${age} ticks)`);
+			console.log(`[Shard] Colonies: ${colonies}`);
+			console.log(`[Shard] Energy: ${energy.toLocaleString()}`);
+			console.log(`[Shard] CPU: ${cpu.toFixed(1)} / Bucket: ${bucket}`);
 			
 			if (detailed) {
 				// Show detailed colony info
 				_.each(Object.keys(status.colonies || {}), colonyName => {
 					let colony = status.colonies[colonyName];
-					console.log(`<font color=\"#00FFFF\">[Shard]</font>   Colony ${colonyName}:`);
-					console.log(`<font color=\"#00FFFF\">[Shard]</font>     RCL: ${colony.rcl}, Energy: ${colony.energy.toLocaleString()}`);
-					console.log(`<font color=\"#00FFFF\">[Shard]</font>     Spawns: ${colony.spawns_available}/${colony.spawns_total}`);
+					console.log(`[Shard]   Colony ${colonyName}:`);
+					console.log(`[Shard]     RCL: ${colony.rcl}, Energy: ${colony.energy.toLocaleString()}`);
+					console.log(`[Shard]     Spawns: ${colony.spawns_available}/${colony.spawns_total}`);
 				});
 				
 				// Show minerals
 				let minerals = _.get(status, ["resources", "minerals"], {});
 				if (Object.keys(minerals).length > 0) {
-					console.log(`<font color=\"#00FFFF\">[Shard]</font> Minerals:`);
+					console.log(`[Shard] Minerals:`);
 					_.each(Object.keys(minerals), mineral => {
-						console.log(`<font color=\"#00FFFF\">[Shard]</font>   ${mineral}: ${minerals[mineral].toLocaleString()}`);
+						console.log(`[Shard]   ${mineral}: ${minerals[mineral].toLocaleString()}`);
 					});
 				}
 			}
 			
-			return `<font color=\"#00FFFF\">[Shard]</font> Status for ${shardName} displayed`;
+			return `[Shard] Status for ${shardName} displayed`;
 		} else {
 			// Show all shards
 			ShardCoordinator.displayStatus();
-			return `<font color=\"#00FFFF\">[Shard]</font> Status displayed`;
+			return `[Shard] Status displayed`;
 		}
 	};
 		
@@ -3215,7 +3212,7 @@
 	
 	shard.portals = function() {
 		Portals.display();
-		return `<font color=\"#00FFFF\">[Shard]</font> Portal list displayed`;
+		return `[Shard] Portal list displayed`;
 	};
 	
 	help_shard.push("shard.colonies(shardName)");
@@ -3224,35 +3221,35 @@
 	
 	shard.colonies = function(shardName) {
 		if (!Game.shard && !shardName) {
-			return `<font color=\"#FF0000\">[Shard]</font> Error: Not on multi-shard server`;
+			return `[Shard] Error: Not on multi-shard server`;
 		}
 		
 		let targetShard = shardName || (Game.shard ? Game.shard.name : null);
 		let status = ShardCoordinator.getShardStatus(targetShard);
 		
 		if (!status) {
-			return `<font color=\"#FF0000\">[Shard]</font> Error: Shard ${targetShard} not found`;
+			return `[Shard] Error: Shard ${targetShard} not found`;
 		}
 		
-		console.log(`<font color=\"#00FFFF\">[Shard]</font> === Colonies on ${targetShard} ===`);
+		console.log(`[Shard] === Colonies on ${targetShard} ===`);
 		
 		let colonies = status.colonies || {};
 		if (Object.keys(colonies).length === 0) {
-			console.log(`<font color=\"#00FFFF\">[Shard]</font> No colonies found`);
+			console.log(`[Shard] No colonies found`);
 		} else {
 			_.each(Object.keys(colonies).sort(), roomName => {
 				let colony = colonies[roomName];
 				let portalIndicator = (colony.portal_rooms && colony.portal_rooms.length > 0) ? " 🌀" : "";
-				console.log(`<font color=\"#00FFFF\">[Shard]</font> ${roomName}${portalIndicator}:`);
-				console.log(`<font color=\"#00FFFF\">[Shard]</font>   RCL: ${colony.rcl}, Energy: ${colony.energy.toLocaleString()}`);
-				console.log(`<font color=\"#00FFFF\">[Shard]</font>   Spawns: ${colony.spawns_available}/${colony.spawns_total}${colony.can_assist ? " (assist available)" : ""}`);
+				console.log(`[Shard] ${roomName}${portalIndicator}:`);
+				console.log(`[Shard]   RCL: ${colony.rcl}, Energy: ${colony.energy.toLocaleString()}`);
+				console.log(`[Shard]   Spawns: ${colony.spawns_available}/${colony.spawns_total}${colony.can_assist ? " (assist available)" : ""}`);
 				if (colony.portal_rooms && colony.portal_rooms.length > 0) {
-					console.log(`<font color=\"#00FFFF\">[Shard]</font>   Portal rooms: ${colony.portal_rooms.join(", ")}`);
+					console.log(`[Shard]   Portal rooms: ${colony.portal_rooms.join(", ")}`);
 				}
 			});
 		}
 		
-		return `<font color=\"#00FFFF\">[Shard]</font> Colonies for ${targetShard} displayed`;
+		return `[Shard] Colonies for ${targetShard} displayed`;
 	};
 	
 	help_shard.push("shard.resources(shardName)");
@@ -3261,45 +3258,45 @@
 	
 	shard.resources = function(shardName) {
 		if (!Game.shard && !shardName) {
-			return `<font color=\"#FF0000\">[Shard]</font> Error: Not on multi-shard server`;
+			return `[Shard] Error: Not on multi-shard server`;
 		}
 		
 		let targetShard = shardName || (Game.shard ? Game.shard.name : null);
 		let status = ShardCoordinator.getShardStatus(targetShard);
 		
 		if (!status) {
-			return `<font color=\"#FF0000\">[Shard]</font> Error: Shard ${targetShard} not found`;
+			return `[Shard] Error: Shard ${targetShard} not found`;
 		}
 		
-		console.log(`<font color=\"#00FFFF\">[Shard]</font> === Resources on ${targetShard} ===`);
+		console.log(`[Shard] === Resources on ${targetShard} ===`);
 		
 		let resources = status.resources || {};
 		
 		// Show energy
 		let energy = resources.energy || 0;
-		console.log(`<font color=\"#00FFFF\">[Shard]</font> Energy: ${energy.toLocaleString()}`);
+		console.log(`[Shard] Energy: ${energy.toLocaleString()}`);
 		
 		// Show minerals
 		let minerals = resources.minerals || {};
 		if (Object.keys(minerals).length > 0) {
-			console.log(`<font color=\"#00FFFF\">[Shard]</font> <b>Minerals:</b>`);
+			console.log(`[Shard] Minerals:`);
 			let mineralKeys = Object.keys(minerals).sort();
 			_.each(mineralKeys, mineral => {
-				console.log(`<font color=\"#00FFFF\">[Shard]</font>   ${mineral}: ${minerals[mineral].toLocaleString()}`);
+				console.log(`[Shard]   ${mineral}: ${minerals[mineral].toLocaleString()}`);
 			});
 		}
 		
 		// Show commodities
 		let commodities = resources.commodities || {};
 		if (Object.keys(commodities).length > 0) {
-			console.log(`<font color=\"#00FFFF\">[Shard]</font> <b>Commodities:</b>`);
+			console.log(`[Shard] Commodities:`);
 			let commodityKeys = Object.keys(commodities).sort();
 			_.each(commodityKeys, commodity => {
-				console.log(`<font color=\"#00FFFF\">[Shard]</font>   ${commodity}: ${commodities[commodity].toLocaleString()}`);
+				console.log(`[Shard]   ${commodity}: ${commodities[commodity].toLocaleString()}`);
 			});
 		}
 		
-		return `<font color=\"#00FFFF\">[Shard]</font> Resources for ${targetShard} displayed`;
+		return `[Shard] Resources for ${targetShard} displayed`;
 	};
 	
 	help_shard.push("shard.debug_ism()");
@@ -3307,7 +3304,7 @@
 		
 		shard.debug_ism = function() {
 			ISM.debug();
-			return `<font color=\"#00FFFF\">[Shard]</font> ISM debug info displayed`;
+			return `[Shard] ISM debug info displayed`;
 		};
 		
 		help_shard.push("shard.colonize(targetShard, targetRoom, options)");
@@ -3318,14 +3315,14 @@
 		
 		shard.colonize = function(targetShard, targetRoom, options = {}) {
 			if (!targetShard || !targetRoom) {
-				return `<font color=\"#FF0000\">[Shard]</font> Error: targetShard and targetRoom required`;
+				return `[Shard] Error: targetShard and targetRoom required`;
 			}
 			
 			let opId = ShardCoordinator.planColonization(targetShard, targetRoom, options);
 			if (opId) {
-				return `<font color=\"#00FF00\">[Shard]</font> Colonization operation ${opId} created`;
+				return `[Shard] Colonization operation ${opId} created`;
 			} else {
-				return `<font color=\"#FF0000\">[Shard]</font> Failed to create colonization operation`;
+				return `[Shard] Failed to create colonization operation`;
 			}
 		};
 		
@@ -3336,27 +3333,27 @@
 			let colonizations = _.get(Memory, ["shard", "operations", "colonizations"], []);
 			let transfers = _.get(Memory, ["shard", "operations", "creep_transfers"], []);
 			
-			console.log(`<font color=\"#00FFFF\">[Shard]</font> === Active Cross-Shard Operations ===`);
+			console.log(`[Shard] === Active Cross-Shard Operations ===`);
 			
 			if (colonizations.length > 0) {
-				console.log(`<font color=\"#00FFFF\">[Shard]</font> <b>Colonizations (${colonizations.length}):</b>`);
+				console.log(`[Shard] Colonizations (${colonizations.length}):`);
 				_.each(colonizations, op => {
-					console.log(`<font color=\"#00FFFF\">[Shard]</font>   ${op.id}: ${op.dest_shard}/${op.dest_room} - ${op.status}`);
+					console.log(`[Shard]   ${op.id}: ${op.dest_shard}/${op.dest_room} - ${op.status}`);
 				});
 			}
 			
 			if (transfers.length > 0) {
-				console.log(`<font color=\"#00FFFF\">[Shard]</font> <b>Creep Transfers (${transfers.length}):</b>`);
+				console.log(`[Shard] Creep Transfers (${transfers.length}):`);
 				_.each(transfers, transfer => {
-					console.log(`<font color=\"#00FFFF\">[Shard]</font>   ${transfer.creep_name}: → ${transfer.dest_shard}/${transfer.dest_room} - ${transfer.status}`);
+					console.log(`[Shard]   ${transfer.creep_name}: → ${transfer.dest_shard}/${transfer.dest_room} - ${transfer.status}`);
 				});
 			}
 			
 			if (colonizations.length === 0 && transfers.length === 0) {
-				console.log(`<font color=\"#00FFFF\">[Shard]</font> No active operations`);
+				console.log(`[Shard] No active operations`);
 			}
 			
-			return `<font color=\"#00FFFF\">[Shard]</font> Operations displayed`;
+			return `[Shard] Operations displayed`;
 		};
 		
 		help_shard.push("shard.clear_operations()");
@@ -3365,7 +3362,7 @@
 	shard.clear_operations = function() {
 		_.set(Memory, ["shard", "operations", "colonizations"], []);
 		_.set(Memory, ["shard", "operations", "creep_transfers"], []);
-		return `<font color=\"#00FFFF\">[Shard]</font> All operations cleared`;
+		return `[Shard] All operations cleared`;
 	};
 
 	help_shard.push("shard.spawn_scout(targetRoom)");
@@ -3376,7 +3373,7 @@
 		// Find an available spawn
 		let spawn = _.find(Game.spawns, s => !s.spawning);
 		if (!spawn) {
-			return `<font color=\"#FF0000\">[Shard]</font> No available spawns`;
+			return `[Shard] No available spawns`;
 		}
 		
 		// Generate scout name using standard naming convention
@@ -3400,9 +3397,9 @@
 		);
 		
 		if (result === OK) {
-			return `<font color=\"#00FF00\">[Shard]</font> Spawning scout ${scoutName} to explore toward ${targetRoom}`;
+			return `[Shard] Spawning scout ${scoutName} to explore toward ${targetRoom}`;
 		} else {
-			return `<font color=\"#FF0000\">[Shard]</font> Failed to spawn scout: ${result}`;
+			return `[Shard] Failed to spawn scout: ${result}`;
 		}
 	};
 
@@ -3415,18 +3412,18 @@
 	shard.fix_scout = function(creepName) {
 		let creep = Game.creeps[creepName];
 		if (!creep) {
-			return `<font color=\"#FF0000\">[Shard]</font> Creep ${creepName} not found`;
+			return `[Shard] Creep ${creepName} not found`;
 		}
 		
 		if (creep.memory.role !== "portal_scout") {
-			return `<font color=\"#FF0000\">[Shard]</font> ${creepName} is not a portal scout`;
+			return `[Shard] ${creepName} is not a portal scout`;
 		}
 		
 		// Fix missing room property
 		creep.memory.room = creep.room.name;
-		console.log(`<font color=\"#00FF00\">[Shard]</font> Fixed scout ${creepName} - set room to ${creep.room.name}`);
+		console.log(`[Shard] Fixed scout ${creepName} - set room to ${creep.room.name}`);
 		
-		return `<font color=\"#00FF00\">[Shard]</font> Fixed scout ${creepName} - set room to ${creep.room.name}`;
+		return `[Shard] Fixed scout ${creepName} - set room to ${creep.room.name}`;
 	};
 	
 	help_shard.push("shard.fix_scout(creepName)");
@@ -3436,31 +3433,31 @@
 	shard.force_scout = function(creepName) {
 		let creep = Game.creeps[creepName];
 		if (!creep) {
-			return `<font color=\"#FF0000\">[Shard]</font> Creep ${creepName} not found`;
+			return `[Shard] Creep ${creepName} not found`;
 		}
 
 		if (creep.memory.role !== "portal_scout") {
-			return `<font color=\"#FF0000\">[Shard]</font> ${creepName} is not a portal scout`;
+			return `[Shard] ${creepName} is not a portal scout`;
 		}
 
 		// Force fix the room property and execute the role immediately
 		creep.memory.room = creep.room.name;
-		console.log(`<font color=\"#00FF00\">[Shard]</font> Fixed and executing scout ${creepName}`);
+		console.log(`[Shard] Fixed and executing scout ${creepName}`);
 
 		// Execute the role directly
 		Creep_Roles.Portal_Scout(creep);
 
-		return `<font color=\"#00FF00\">[Shard]</font> Fixed and executed scout ${creepName}`;
+		return `[Shard] Fixed and executed scout ${creepName}`;
 	};
 
 	shard.reset_scout = function(creepName) {
 		let creep = Game.creeps[creepName];
 		if (!creep) {
-			return `<font color=\"#FF0000\">[Shard]</font> Creep ${creepName} not found`;
+			return `[Shard] Creep ${creepName} not found`;
 		}
 
 		if (creep.memory.role !== "portal_scout") {
-			return `<font color=\"#FF0000\">[Shard]</font> ${creepName} is not a portal scout`;
+			return `[Shard] ${creepName} is not a portal scout`;
 		}
 
 		// Reset scout to exploration mode
@@ -3472,9 +3469,9 @@
 		creep.memory.explore_mode = true;
 		creep.memory.room = creep.room.name;
 
-		console.log(`<font color=\"#00FF00\">[Shard]</font> Reset scout ${creepName} to exploration mode`);
+		console.log(`[Shard] Reset scout ${creepName} to exploration mode`);
 
-		return `<font color=\"#00FF00\">[Shard]</font> Reset scout ${creepName} to exploration mode`;
+		return `[Shard] Reset scout ${creepName} to exploration mode`;
 	};
 	
 	help_shard.push("shard.force_scout(creepName)");
@@ -3500,22 +3497,22 @@
 	
 	global_creeps.stats = function() {
 		let stats = GlobalCreeps.getStats();
-		console.log(`<font color="#00FFFF">[GlobalCreeps]</font> === Global Creep Statistics ===`);
-		console.log(`<font color="#00FFFF">[GlobalCreeps]</font> Total: ${stats.total} global creeps`);
+		console.log(`[GlobalCreeps] === Global Creep Statistics ===`);
+		console.log(`[GlobalCreeps] Total: ${stats.total} global creeps`);
 		
 		if (stats.total > 0) {
-			console.log(`<font color="#00FFFF">[GlobalCreeps]</font> By Role:`);
+			console.log(`[GlobalCreeps] By Role:`);
 			_.each(Object.keys(stats.byRole), role => {
-				console.log(`<font color="#00FFFF">[GlobalCreeps]</font>   ${role}: ${stats.byRole[role]}`);
+				console.log(`[GlobalCreeps]   ${role}: ${stats.byRole[role]}`);
 			});
 			
-			console.log(`<font color="#00FFFF">[GlobalCreeps]</font> Creeps:`);
+			console.log(`[GlobalCreeps] Creeps:`);
 			_.each(stats.creeps, creep => {
-				console.log(`<font color="#00FFFF">[GlobalCreeps]</font>   ${creep.name} (${creep.role}) in ${creep.room} [assigned: ${creep.assignedRoom}]`);
+				console.log(`[GlobalCreeps]   ${creep.name} (${creep.role}) in ${creep.room} [assigned: ${creep.assignedRoom}]`);
 			});
 		}
 		
-		return `<font color="#00FF00">[GlobalCreeps]</font> ${stats.total} global creeps found`;
+		return `[GlobalCreeps] ${stats.total} global creeps found`;
 	};
 	
 	help_global_creeps.push("global_creeps.stats()");
@@ -3525,11 +3522,11 @@
 	global_creeps.assign_worker = function(creepName, targetRoom) {
 		let creep = Game.creeps[creepName];
 		if (!creep) {
-			return `<font color="#FF0000">[GlobalCreeps]</font> Creep ${creepName} not found`;
+			return `[GlobalCreeps] Creep ${creepName} not found`;
 		}
 		
 		creep.memory.remote_target = targetRoom;
-		return `<font color="#00FF00">[GlobalCreeps]</font> Assigned ${creepName} to remote mine in ${targetRoom}`;
+		return `[GlobalCreeps] Assigned ${creepName} to remote mine in ${targetRoom}`;
 	};
 	
 	help_global_creeps.push("global_creeps.assign_worker(creepName, targetRoom)");
@@ -3541,11 +3538,11 @@
 	global_creeps.assign_highway = function(creepName, targetRoom) {
 		let creep = Game.creeps[creepName];
 		if (!creep) {
-			return `<font color="#FF0000">[GlobalCreeps]</font> Creep ${creepName} not found`;
+			return `[GlobalCreeps] Creep ${creepName} not found`;
 		}
 		
 		creep.memory.highway_target = targetRoom;
-		return `<font color="#00FF00">[GlobalCreeps]</font> Assigned ${creepName} to highway mine in ${targetRoom}`;
+		return `[GlobalCreeps] Assigned ${creepName} to highway mine in ${targetRoom}`;
 	};
 	
 	help_global_creeps.push("global_creeps.assign_highway(creepName, targetRoom)");
@@ -3557,7 +3554,7 @@
 	global_creeps.spawn_resource_scout = function(targetRoom) {
 		let spawn = _.find(Game.spawns, s => !s.spawning);
 		if (!spawn) {
-			return `<font color="#FF0000">[GlobalCreeps]</font> No available spawns`;
+			return `[GlobalCreeps] No available spawns`;
 		}
 		
 		let scoutName = "rsct:" + Math.floor(Math.random() * 0xFFFF).toString(16).padStart(4, "0");
@@ -3574,9 +3571,9 @@
 		});
 		
 		if (result === OK) {
-			return `<font color="#00FF00">[GlobalCreeps]</font> Spawning resource scout ${scoutName} to scan ${targetRoom}`;
+			return `[GlobalCreeps] Spawning resource scout ${scoutName} to scan ${targetRoom}`;
 		} else {
-			return `<font color="#FF0000">[GlobalCreeps]</font> Failed to spawn: ${result}`;
+			return `[GlobalCreeps] Failed to spawn: ${result}`;
 		}
 	};
 	
@@ -3590,15 +3587,15 @@
 		let resources = _.get(Memory, ["global_resources", currentShard], {});
 		
 		if (Object.keys(resources).length === 0) {
-			return `<font color="#FFFF00">[Resources]</font> No resources discovered yet`;
+			return `[Resources] No resources discovered yet`;
 		}
 		
-		console.log(`<font color="#FFFF00">[Resources]</font> === Discovered Resources (${currentShard}) ===`);
+		console.log(`[Resources] === Discovered Resources (${currentShard}) ===`);
 		
 		let byType = _.groupBy(Object.values(resources), r => r.type);
 		
 		_.each(Object.keys(byType), type => {
-			console.log(`<font color="#FFFF00">[Resources]</font> ${type}: ${byType[type].length}`);
+			console.log(`[Resources] ${type}: ${byType[type].length}`);
 			_.each(byType[type], resource => {
 				let age = Game.time - resource.discovered;
 				let info = "";
@@ -3611,11 +3608,11 @@
 					info = `${resource.mineralType}, ${resource.mineralAmount} amount`;
 				}
 				
-				console.log(`<font color="#FFFF00">[Resources]</font>   ${resource.room} ${info} (${age} ticks ago)`);
+				console.log(`[Resources]   ${resource.room} ${info} (${age} ticks ago)`);
 			});
 		});
 		
-		return `<font color="#00FF00">[Resources]</font> ${Object.keys(resources).length} resources found`;
+		return `[Resources] ${Object.keys(resources).length} resources found`;
 	};
 	
 	help_global_creeps.push("global_creeps.list_resources()");
@@ -3628,29 +3625,29 @@
 	shard.test_portal = function(creepName, targetShard, targetRoom) {
 		let creep = Game.creeps[creepName];
 		if (!creep) {
-			return `<font color=\"#FF0000\">[Shard]</font> Creep ${creepName} not found`;
+			return `[Shard] Creep ${creepName} not found`;
 		}
 		
 		// Check for portal route
 		let route = Portals.getPortalRoute(creep.room.name, targetShard, targetRoom);
 		if (!route) {
-			return `<font color=\"#FF0000\">[Shard]</font> No portal route from ${creep.room.name} to ${targetShard}`;
+			return `[Shard] No portal route from ${creep.room.name} to ${targetShard}`;
 		}
 		
 		// Display route info
-		console.log(`<font color=\"#00FFFF\">[Shard]</font> Portal route found:`);
-		console.log(`<font color=\"#00FFFF\">[Shard]</font>   Portal: ${route.portal.pos.roomName} (${route.portal.pos.x}, ${route.portal.pos.y})`);
-		console.log(`<font color=\"#00FFFF\">[Shard]</font>   Destination: ${route.destShard} / ${route.destRoom}`);
-		console.log(`<font color=\"#00FFFF\">[Shard]</font>   Distance: ${route.distance} rooms`);
-		console.log(`<font color=\"#00FFFF\">[Shard]</font>   ETA: ${route.estimatedTravelTime} ticks`);
-		console.log(`<font color=\"#00FFFF\">[Shard]</font>   Cached: ${route.cached}`);
+		console.log(`[Shard] Portal route found:`);
+		console.log(`[Shard]   Portal: ${route.portal.pos.roomName} (${route.portal.pos.x}, ${route.portal.pos.y})`);
+		console.log(`[Shard]   Destination: ${route.destShard} / ${route.destRoom}`);
+		console.log(`[Shard]   Distance: ${route.distance} rooms`);
+		console.log(`[Shard]   ETA: ${route.estimatedTravelTime} ticks`);
+		console.log(`[Shard]   Cached: ${route.cached}`);
 		
 		// Initiate travel
 		creep.memory.test_mode = true;
 		creep.memory.portal_target_shard = targetShard;
 		creep.memory.portal_target_room = targetRoom;
 		
-		return `<font color=\"#00FF00\">[Shard]</font> ${creepName} will travel to ${targetShard}/${targetRoom} via portal`;
+		return `[Shard] ${creepName} will travel to ${targetShard}/${targetRoom} via portal`;
 	};
 
 
@@ -3678,8 +3675,8 @@
 				}
 			}
 
-			console.log(`<font color=\"#D3FFA3\">Command list:</font> <br>${menu.join("<br>")}<br><br>`);
-			return `<font color=\"#D3FFA3\">[Console]</font> Help("${submenu}") list complete`;
+			console.log(`Command list: \n${menu.join("\n")}\n\n`);
+			return `[Console] Help("${submenu}") list complete`;
 		};
 	}
 };

--- a/definitions_cpu_profiling.js
+++ b/definitions_cpu_profiling.js
@@ -11,18 +11,18 @@
 			_.set(Memory, ["hive", "profiler", "cycles_total"], (cycles == null) ? 1 : cycles);
 			_.set(Memory, ["hive", "profiler", "status"], "on");
 			_.set(Memory, ["hive", "profiler", "pulses"], new Object());
-			return "<font color=\"#D3FFA3\">[CPU]</font> Profiler started"
+			return "[CPU] Profiler started"
 		};
 
 		profiler.stop = function () {
 			_.set(Memory, ["hive", "profiler", "cycles"], 0);
-			return "<font color=\"#D3FFA3\">[CPU]</font> Profiler stopped"
+			return "[CPU] Profiler stopped"
 		};
 
 		// Enhanced profiling with optimization analysis
 		profiler.analyze = function () {
 			let current = _.get(Memory, ["hive", "profiler", "current"]);
-			if (!current) return "<font color=\"#FF6B6B\">[CPU]</font> No profiling data available. Run profiler.run() first.";
+			if (!current) return "[CPU] No profiling data available. Run profiler.run() first.";
 			
 			let analysis = {
 				hotspots: [],
@@ -77,16 +77,16 @@
 			analysis.hotspots.sort((a, b) => b.avgCPU - a.avgCPU);
 			
 			// Console output
-			console.log(`<font color=\"#D3FFA3\">[CPU Analysis]</font> <b>Performance Analysis:</b>`);
-			console.log(`<font color=\"#D3FFA3\">[CPU Analysis]</font> Total CPU: ${analysis.totalCPU.toFixed(2)}`);
+			console.log(`[CPU Analysis] Performance Analysis:`);
+			console.log(`[CPU Analysis] Total CPU: ${analysis.totalCPU.toFixed(2)}`);
 			
 			if (analysis.hotspots.length > 0) {
-				console.log(`<font color=\"#FF6B6B\">[CPU Analysis]</font> <b>CPU Hotspots Found:</b>`);
+				console.log(`[CPU Analysis] CPU Hotspots Found:`);
 				_.each(analysis.hotspots.slice(0, 5), hotspot => {
 					console.log(`  ${hotspot.room}.${hotspot.function}: ${hotspot.avgCPU.toFixed(2)} avg CPU`);
 				});
 				
-				console.log(`<font color=\"#FFA500\">[CPU Analysis]</font> <b>Optimization Recommendations:</b>`);
+				console.log(`[CPU Analysis] Optimization Recommendations:`);
 				_.each(analysis.hotspots.slice(0, 3), hotspot => {
 					if (hotspot.avgCPU > 1.0) {
 						console.log(`  ⚠️  ${hotspot.room}.${hotspot.function}: Consider caching or reducing frequency`);
@@ -95,16 +95,16 @@
 					}
 				});
 			} else {
-				console.log(`<font color=\"#47FF3E\">[CPU Analysis]</font> <b>✅ No major CPU hotspots detected!</b>`);
+				console.log(`[CPU Analysis] ✅ No major CPU hotspots detected!`);
 			}
 			
 			// Room breakdown
-			console.log(`<font color=\"#D3FFA3\">[CPU Analysis]</font> <b>Room CPU Breakdown:</b>`);
+			console.log(`[CPU Analysis] Room CPU Breakdown:`);
 			_.each(analysis.roomBreakdown, (data, room) => {
 				console.log(`  ${room}: ${data.totalCPU.toFixed(2)} CPU`);
 			});
 			
-			return `<font color=\"#D3FFA3\">[CPU Analysis]</font> Analysis complete.`;
+			return `[CPU Analysis] Analysis complete.`;
 		};
 
 		if (_.get(Memory, ["hive", "profiler"]) == null)
@@ -161,7 +161,7 @@
 		if (_.get(Memory, ["hive", "profiler", "cycles"]) <= 0) {
 			let total_cycles = _.get(Memory, ["hive", "profiler", "cycles_total"]);
 
-			console.log(`<font color=\"#D3FFA3">Pulses during profiling: \n`
+			console.log(`Pulses during profiling: \n`
 				+ `Short:\t ${_.get(Memory, ["hive", "profiler", "pulses", "short"], 0)} \n`
 				+ `Mid:\t ${_.get(Memory, ["hive", "profiler", "pulses", "mid"], 0)} \n`
 				+ `Long:\t ${_.get(Memory, ["hive", "profiler", "pulses", "long"], 0)} \n`
@@ -177,7 +177,8 @@
 					let cycles = Object.keys(_.get(Memory, ["hive", "profiler", "current", r, n])).length;
 					_.forEach(_.get(Memory, ["hive", "profiler", "current", r, n]), c => { used += _.get(c, "used", 0); });
 					used = ((used > 0 == true) ? used : 0);
-					output += `<tr><td>(${parseFloat(used).toFixed(2)} / ${cycles})</td><td>${parseFloat(used / cycles).toFixed(2)}</td><td>${n}</td></tr>`;
+					output += `(${parseFloat(used).toFixed(2)} / ${cycles})	${parseFloat(used / cycles).toFixed(2)}	${n}	
+`;
 
 					room_used += used;
 					if (typeof (room_cycles) != "number")
@@ -185,17 +186,18 @@
 					room_cycles = Math.max(room_cycles, cycles);
 				}
 
-				console.log(`<font color=\"#D3FFA3">CPU report for ${r} \n`
+				console.log(`CPU report for ${r} \n`
 					+ `Room Total: ${parseFloat(room_used).toFixed(2)} : `
-					+ `Room Mean: ${parseFloat(room_used / total_cycles).toFixed(2)}</font> `
-					+ `<table><tr><th>Total / Cycles\t  </th><th>Mean\t  </th><th>Function</th></tr>`
-					+ `${output}</table>`);
+					+ `Room Mean: ${parseFloat(room_used / total_cycles).toFixed(2)} `
+					+ `Total / Cycles\t  	Mean\t  	Function	
+`
+					+ `${output}`);
 			}
 
 			_.set(Memory, ["hive", "profiler", "status"], "off");
 			_.set(Memory, ["hive", "profiler", "current"], new Object());	// Wipe for the next use
 		} else if (_.get(Memory, ["hive", "profiler", "cycles"]) % 5 == 0) {
-			console.log(`<font color=\"#D3FFA3\">[CPU]</font> Profiler running, ${_.get(Memory, ["hive", "profiler", "cycles"])} ticks remaining.`);
+			console.log(`[CPU] Profiler running, ${_.get(Memory, ["hive", "profiler", "cycles"])} ticks remaining.`);
 		}
 	}
 };

--- a/definitions_creep_roles.js
+++ b/definitions_creep_roles.js
@@ -1693,13 +1693,9 @@
 				// Final fallback: wait if no tasks available
 				creep.memory.task = creep.memory.task || creep.getTask_Wait(5);
 
-			} else if (creep.memory.role == "miner" || creep.memory.role == "carrier") {
-					creep.memory.task = creep.memory.task || creep.getTask_Pickup("energy");
-					
-					// PRIORITY 3: Withdraw from link (efficient transfer point)
-					creep.memory.task = creep.memory.task || creep.getTask_Withdraw_Link(15);
-
-					// PRIORITY 4: Withdraw from containers/storage (only if can't mine)
+			} else if (creep.memory.role == "miner") {
+					// Miners are bootstrap creeps - can restart a room if other creeps die
+					// PRIORITY 1: Withdraw from existing containers/storage with energy
 					let energy_level = _.get(Memory, ["rooms", creep.room.name, "survey", "energy_level"]);
 					if (energy_level == CRITICAL || energy_level == LOW
 						|| _.get(Memory, ["sites", "mining", creep.memory.room, "store_percent"], 0) > 0.25) {
@@ -1710,10 +1706,42 @@
 						creep.memory.task = creep.memory.task || creep.getTask_Withdraw_Container("energy", true);
 					}
 
+					// PRIORITY 2: Withdraw from link (efficient transfer point)
+					creep.memory.task = creep.memory.task || creep.getTask_Withdraw_Link(15);
+
+					// PRIORITY 3: Mine from sources (bootstrap fallback - restart mechanism)
+					creep.memory.task = creep.memory.task || creep.getTask_Mine();
+
+					// PRIORITY 4: Pickup dropped energy from ground
+					creep.memory.task = creep.memory.task || creep.getTask_Pickup("energy");
+
 					// PRIORITY 5: Pick up minerals if available
 					creep.memory.task = creep.memory.task || creep.getTask_Pickup("mineral");
 					
 					// PRIORITY 6: Wait as last resort
+					creep.memory.task = creep.memory.task || creep.getTask_Wait(10);
+					
+			} else if (creep.memory.role == "carrier") {
+					creep.memory.task = creep.memory.task || creep.getTask_Pickup("energy");
+					
+					// Withdraw from link (efficient transfer point)
+					creep.memory.task = creep.memory.task || creep.getTask_Withdraw_Link(15);
+
+					// Withdraw from containers/storage (only if can't mine)
+					let energy_level = _.get(Memory, ["rooms", creep.room.name, "survey", "energy_level"]);
+					if (energy_level == CRITICAL || energy_level == LOW
+						|| _.get(Memory, ["sites", "mining", creep.memory.room, "store_percent"], 0) > 0.25) {
+						creep.memory.task = creep.memory.task || creep.getTask_Withdraw_Container("energy", true);
+						creep.memory.task = creep.memory.task || creep.getTask_Withdraw_Storage("energy", true);
+					} else {
+						creep.memory.task = creep.memory.task || creep.getTask_Withdraw_Storage("energy", true);
+						creep.memory.task = creep.memory.task || creep.getTask_Withdraw_Container("energy", true);
+					}
+
+					// Pick up minerals if available
+					creep.memory.task = creep.memory.task || creep.getTask_Pickup("mineral");
+					
+					// Wait as last resort
 					creep.memory.task = creep.memory.task || creep.getTask_Wait(10);
 				}
 

--- a/definitions_creep_roles.js
+++ b/definitions_creep_roles.js
@@ -106,9 +106,9 @@
 			return;
 		}
 		
-		debugLog(2, `<font color="#4ECDC4">[Scout]</font> recordTransferSnapshot called for ${creep.name} - target: ${targetShard}/${targetRoom}`, 10);
+		debugLog(2, `[Scout] recordTransferSnapshot called for ${creep.name} - target: ${targetShard}/${targetRoom}`, 10);
 
-		debugLog(2, `<font color="#4ECDC4">[Scout]</font> Recording transfer snapshot for ${creep.name}`, 10);
+		debugLog(2, `[Scout] Recording transfer snapshot for ${creep.name}`, 10);
 		let snapshot;
 			try {
 				snapshot = JSON.parse(JSON.stringify(creep.memory || {}));
@@ -145,7 +145,7 @@
 			};
 
 		if (Memory && _.get(Memory, ["hive", "ism", "debug_transfers"])) {
-			console.log(`<font color="#9B5DE5">[Scout]</font> transferData for ${creep.name} -> ${JSON.stringify(_.pick(transferData, ["destination_shard","destination_room","origin_shard","portal","transfer_time"]))}`);
+			console.log(`[Scout] transferData for ${creep.name} -> ${JSON.stringify(_.pick(transferData, ["destination_shard","destination_room","origin_shard","portal","transfer_time"]))}`);
 		}
 
 			creep.memory.global_status = "transferring";
@@ -186,11 +186,11 @@
 			}
 
 			if (typeof ShardMemory !== "undefined" && _.isFunction(_.get(ShardMemory, "recordCreepTransfer"))) {
-				console.log(`<font color="#4ECDC4">[Scout]</font> Storing transfer via ShardMemory for ${creep.name}`);
+				console.log(`[Scout] Storing transfer via ShardMemory for ${creep.name}`);
 				ShardMemory.recordCreepTransfer(creep.name, transferData, {
 					descriptor: descriptor
 				});
-				console.log(`<font color="#4ECDC4">[Scout]</font> snapshot stored for ${creep.name}`);
+				console.log(`[Scout] snapshot stored for ${creep.name}`);
 			} else {
 				let ismData = InterShardMemory.getLocal() ? JSON.parse(InterShardMemory.getLocal()) : {};
 				if (!_.isObject(ismData))
@@ -202,10 +202,10 @@
 					ismData.global_creeps = {};
 				ismData.global_creeps[creep.name] = descriptor;
 				InterShardMemory.setLocal(JSON.stringify(ismData));
-				debugLog(2, `<font color="#4ECDC4">[Scout]</font> snapshot stored for ${creep.name}`, 10);
+				debugLog(2, `[Scout] snapshot stored for ${creep.name}`, 10);
 			}
 		} catch (err) {
-			debugLog(1, `<font color="#FFA500">[Scout]</font> Failed to record transfer for ${creep.name}: ${err.message}`, 0);
+			debugLog(1, `[Scout] Failed to record transfer for ${creep.name}: ${err.message}`, 0);
 		}
 
 		creep.memory._scout_next_portal_allowed = Game.time + 20;
@@ -241,7 +241,7 @@
 			return;
 		}
 
-		debugLog(2, `<font color="#4ECDC4">[Scout]</font> Attempting restoration for ${creep.name} on shard ${Game.shard.name}`, 0);
+		debugLog(2, `[Scout] Attempting restoration for ${creep.name} on shard ${Game.shard.name}`, 0);
 		let transferData = null;
 
 		for (let i = 0; i < knownShards.length; i++) {
@@ -275,7 +275,7 @@
 
 			if (entry) {
 				transferData = entry;
-				debugLog(2, `<font color="#4ECDC4">[Scout]</font> Found transfer for ${creep.name} from ${shardName}`, 0);
+				debugLog(2, `[Scout] Found transfer for ${creep.name} from ${shardName}`, 0);
 				break;
 			}
 		}
@@ -286,19 +286,19 @@
 				offer = ShardMemory.getHandshakeOffer(creep.name, true);
 			}
 			if (_.get(offer, "transfer_data")) {
-				debugLog(2, `<font color="#4ECDC4">[Scout]</font> Using handshake backup transfer for ${creep.name}`, 0);
+				debugLog(2, `[Scout] Using handshake backup transfer for ${creep.name}`, 0);
 				transferData = _.get(offer, "transfer_data");
 			} else {
 				// Log once per creep to avoid console spam when transfer data never arrives
 				if (!creep.memory._scout_transfer_missing_logged) {
 					creep.memory._scout_transfer_missing_logged = true;
-					debugLog(1, `<font color="#FFD700">[Scout]</font> No transfer data found for ${creep.name}`, 0);
+					debugLog(1, `[Scout] No transfer data found for ${creep.name}`, 0);
 				}
 				return;
 			}
 		}
 
-		debugLog(2, `<font color="#4ECDC4">[Scout]</font> Restoring memory for ${creep.name} from transfer data`, 0);
+		debugLog(2, `[Scout] Restoring memory for ${creep.name} from transfer data`, 0);
 		let snapshot = _.get(transferData, "memory");
 
 		if (_.isObject(snapshot)) {
@@ -443,7 +443,7 @@
 				}
 			}
 			
-			debugLog(1, `<font color="#4ECDC4">[Scout]</font> ${creep.name} restored on ${Game.shard.name}: patrol_state=${creep.memory.scout_patrol_state}, mode=${patrolMode}, dest_reached=${creep.memory.scout_dest_reached}, rally_reached=${creep.memory.scout_rally_reached}, at_rally=${atRallyPos}, at_dest=${atDestPos}`, 0);
+			debugLog(1, `[Scout] ${creep.name} restored on ${Game.shard.name}: patrol_state=${creep.memory.scout_patrol_state}, mode=${patrolMode}, dest_reached=${creep.memory.scout_dest_reached}, rally_reached=${creep.memory.scout_rally_reached}, at_rally=${atRallyPos}, at_dest=${atDestPos}`, 0);
 
 			creep.memory._scout_next_portal_allowed = Game.time + 20;
 			creep.memory._scout_last_shard_switch = Game.time;
@@ -485,7 +485,7 @@
 				if (typeof ShardMemory !== "undefined" && _.isFunction(_.get(ShardMemory, "registerGlobalCreep")))
 					ShardMemory.registerGlobalCreep(creep.name, descriptor);
 			} catch (err) {
-				debugLog(1, `<font color="#FFA500">[Scout]</font> Failed to update ISM for restored ${creep.name}: ${err.message}`, 0);
+				debugLog(1, `[Scout] Failed to update ISM for restored ${creep.name}: ${err.message}`, 0);
 			}
 		};
 
@@ -765,7 +765,7 @@
 					let returnToShard = _.get(intent, "return_portal.destination_shard", colonyShard);
 					let returnToRoom = _.get(intent, "return_portal.destination_room", null);
 					
-					debugLog(2, `<font color="#4ECDC4">[Scout]</font> ${creep.name} registering return portal: ${returnFromShard}/${ret.roomName} -> ${returnToShard}/${returnToRoom || "?"}`, 50);
+					debugLog(2, `[Scout] ${creep.name} registering return portal: ${returnFromShard}/${ret.roomName} -> ${returnToShard}/${returnToRoom || "?"}`, 50);
 					
 					registerEntry(
 						returnFromShard,
@@ -859,7 +859,7 @@
 			if (!portalEntry) {
 				let warnTick = _.get(creep.memory, "_scout_portal_warn");
 				if (!warnTick || warnTick + 50 < Game.time) {
-					debugLog(1, `<font color="#FF944E">[Scout]</font> ${creep.name} missing portal entry for ${targetShard}/${targetRoom || "?"} (state=${currentPatrolState})`, 0);
+					debugLog(1, `[Scout] ${creep.name} missing portal entry for ${targetShard}/${targetRoom || "?"} (state=${currentPatrolState})`, 0);
 					creep.memory._scout_portal_warn = Game.time;
 				}
 				return false;
@@ -907,10 +907,10 @@
 			let awaitingAck = shouldWaitForTransferAck(targetShard);
 			if (awaitingAck) {
 				creep.memory._awaiting_transfer_ack = true;
-				debugLog(2, `<font color="#4ECDC4">[Scout]</font> ${creep.name} awaiting transfer acknowledgement to ${targetShard}/${targetRoom || "?"}`, 10);
+				debugLog(2, `[Scout] ${creep.name} awaiting transfer acknowledgement to ${targetShard}/${targetRoom || "?"}`, 10);
 			} else {
 				if (_.get(creep.memory, "_awaiting_transfer_ack") === true) {
-					debugLog(2, `<font color="#4ECDC4">[Scout]</font> ${creep.name} received transfer acknowledgement for ${targetShard}/${targetRoom || "?"}`, 0);
+					debugLog(2, `[Scout] ${creep.name} received transfer acknowledgement for ${targetShard}/${targetRoom || "?"}`, 0);
 					creep.say("GO!");
 				}
 				delete creep.memory._awaiting_transfer_ack;
@@ -1032,7 +1032,7 @@
 				}
 			}
 
-			debugLog(1, `<font color="#4ECDC4">[Scout]</font> ${creep.name} shard switch: ${current} -> ${Game.shard.name}, patrol_state=${creep.memory.scout_patrol_state}, mode=${currentPatrolMode}, dest_reached=${destReached}, rally_reached=${rallyReached}`, 0);
+			debugLog(1, `[Scout] ${creep.name} shard switch: ${current} -> ${Game.shard.name}, patrol_state=${creep.memory.scout_patrol_state}, mode=${currentPatrolMode}, dest_reached=${destReached}, rally_reached=${rallyReached}`, 0);
 
 			creep.memory._scout_next_portal_allowed = Game.time + 20;
 			creep.memory._scout_last_shard_switch = Game.time;
@@ -1126,7 +1126,7 @@
 				// On destination shard
 				if (atDestPos && state !== "to_rally" && shouldCorrect) {
 					// Actually at destination position, should be heading back to rally
-					debugLog(1, `<font color="#FF944E">[Scout]</font> ${creep.name} correcting state: ${state} -> to_rally (at dest pos)`, 0);
+					debugLog(1, `[Scout] ${creep.name} correcting state: ${state} -> to_rally (at dest pos)`, 0);
 					if (typeof creep.travelClear === "function")
 						creep.travelClear();
 					creep.memory.scout_patrol_state = "to_rally";
@@ -1136,7 +1136,7 @@
 					state = "to_rally";
 				} else if (!atDestPos && !destReached && state !== "to_dest" && shouldCorrect) {
 					// Haven't reached destination yet, should be heading to destination
-					debugLog(1, `<font color="#FF944E">[Scout]</font> ${creep.name} correcting state: ${state} -> to_dest (on dest shard, dest not reached)`, 0);
+					debugLog(1, `[Scout] ${creep.name} correcting state: ${state} -> to_dest (on dest shard, dest not reached)`, 0);
 					if (typeof creep.travelClear === "function")
 						creep.travelClear();
 					creep.memory.scout_patrol_state = "to_dest";
@@ -1145,7 +1145,7 @@
 					state = "to_dest";
 				} else if (destReached && state !== "to_rally" && shouldCorrect) {
 					// Reached destination (flag set), should be heading back to rally
-					debugLog(1, `<font color="#FF944E">[Scout]</font> ${creep.name} correcting state: ${state} -> to_rally (on dest shard, dest reached)`, 0);
+					debugLog(1, `[Scout] ${creep.name} correcting state: ${state} -> to_rally (on dest shard, dest reached)`, 0);
 					if (typeof creep.travelClear === "function")
 						creep.travelClear();
 					creep.memory.scout_patrol_state = "to_rally";
@@ -1157,7 +1157,7 @@
 				// On rally shard
 				if (atRallyPos && state !== "to_dest" && shouldCorrect) {
 					// Actually at rally position, should be heading to destination
-					debugLog(1, `<font color="#FF944E">[Scout]</font> ${creep.name} correcting state: ${state} -> to_dest (at rally pos)`, 0);
+					debugLog(1, `[Scout] ${creep.name} correcting state: ${state} -> to_dest (at rally pos)`, 0);
 					if (typeof creep.travelClear === "function")
 						creep.travelClear();
 					creep.memory.scout_patrol_state = "to_dest";
@@ -1167,7 +1167,7 @@
 					state = "to_dest";
 				} else if (!atRallyPos && !rallyReached && state !== "to_rally" && shouldCorrect) {
 					// Haven't reached rally yet, should be heading to rally
-					debugLog(1, `<font color="#FF944E">[Scout]</font> ${creep.name} correcting state: ${state} -> to_rally (on rally shard, rally not reached)`, 0);
+					debugLog(1, `[Scout] ${creep.name} correcting state: ${state} -> to_rally (on rally shard, rally not reached)`, 0);
 					if (typeof creep.travelClear === "function")
 						creep.travelClear();
 					creep.memory.scout_patrol_state = "to_rally";
@@ -1176,7 +1176,7 @@
 					state = "to_rally";
 				} else if (rallyReached && state !== "to_dest" && shouldCorrect) {
 					// Reached rally (flag set), should be heading to destination
-					debugLog(1, `<font color="#FF944E">[Scout]</font> ${creep.name} correcting state: ${state} -> to_dest (on rally shard, rally reached)`, 0);
+					debugLog(1, `[Scout] ${creep.name} correcting state: ${state} -> to_dest (on rally shard, rally reached)`, 0);
 					if (typeof creep.travelClear === "function")
 						creep.travelClear();
 					creep.memory.scout_patrol_state = "to_dest";
@@ -1216,7 +1216,7 @@
 					return;
 				}
 				// Reached destination - switch to heading to rally
-				debugLog(1, `<font color="#4ECDC4">[Scout]</font> ${creep.name} reached destination, switching to rally`, 0);
+				debugLog(1, `[Scout] ${creep.name} reached destination, switching to rally`, 0);
 				creep.memory.scout_patrol_state = "to_rally";
 				creep.memory.scout_dest_reached = true;
 				creep.memory.scout_rally_reached = false;
@@ -1256,7 +1256,7 @@
 					return;
 				}
 				// Reached rally - switch to heading to destination (start next loop)
-				debugLog(1, `<font color="#4ECDC4">[Scout]</font> ${creep.name} reached rally, switching to destination`, 0);
+				debugLog(1, `[Scout] ${creep.name} reached rally, switching to destination`, 0);
 				creep.memory.scout_patrol_state = "to_dest";
 				creep.memory.scout_rally_reached = true;
 				creep.memory.scout_dest_reached = false;
@@ -1317,14 +1317,14 @@
 			
 			// Check if we're already on the target shard
 			if (currentShard === creep.memory.portal_target_shard) {
-				console.log(`<font color="#00FF00">[Scout]</font> ${creep.name} successfully arrived on ${currentShard}!`);
+				console.log(`[Scout] ${creep.name} successfully arrived on ${currentShard}!`);
 				
 				// Move to target room on this shard
 				if (creep.room.name !== creep.memory.portal_target_room) {
 					let targetPos = new RoomPosition(25, 25, creep.memory.portal_target_room);
 					creep.travel(targetPos);
 				} else {
-					console.log(`<font color="#00FF00">[Scout]</font> ${creep.name} reached destination room ${creep.room.name}!`);
+					console.log(`[Scout] ${creep.name} reached destination room ${creep.room.name}!`);
 					// Mission complete - suicide or wander
 					creep.say("✓Portal!");
 				}
@@ -1336,7 +1336,7 @@
 				);
 				
 				if (result === ERR_NO_PATH) {
-					console.log(`<font color="#FF0000">[Scout]</font> ${creep.name} cannot find portal route`);
+					console.log(`[Scout] ${creep.name} cannot find portal route`);
 					creep.say("No portal");
 				} else {
 					creep.say("→Portal");
@@ -1441,7 +1441,7 @@
 						if (!creep.memory.auto_test_attempted) {
 							let shard3Portal = _.find(portals, p => p.destination.shard === "shard3");
 							if (shard3Portal && currentShard !== "shard3") {
-								console.log(`<font color="#00FFFF">[Scout]</font> ${creep.name} auto-testing portal traversal to shard3!`);
+								console.log(`[Scout] ${creep.name} auto-testing portal traversal to shard3!`);
 								creep.memory.auto_test_attempted = true;
 								creep.memory.test_mode = true;
 								creep.memory.portal_target_shard = "shard3";
@@ -2034,7 +2034,7 @@
 			// CRITICAL: Check if this is a transferred colonizer that needs memory restoration
 			// Must run EVERY TICK, not just every 5 ticks, to catch recent transfers
 			if (!creep.memory.role) {
-				console.log(`<font color="#FFA500">[Colonizer]</font> ${creep.name} has no role, attempting memory restoration`);
+				console.log(`[Colonizer] ${creep.name} has no role, attempting memory restoration`);
 			
 			// Check shard0's master ISM for transfer data
 			try {
@@ -2045,10 +2045,10 @@
 					// Try both old "transfers" and new "creep_transfers" key names
 					transferData = _.get(parsed, ["creep_transfers", creep.name], null) 
 						|| _.get(parsed, ["transfers", creep.name], null);
-					console.log(`<font color="#FFA500">[Colonizer]</font> ${creep.name} looking in ISM, found: ${transferData ? 'yes' : 'no'}`);
+					console.log(`[Colonizer] ${creep.name} looking in ISM, found: ${transferData ? 'yes' : 'no'}`);
 				}
 				if (transferData) {
-						console.log(`<font color="#4ECDC4">[Colonizer]</font> Found transfer data for ${creep.name}: role=${transferData.role}, room=${transferData.room}`);
+						console.log(`[Colonizer] Found transfer data for ${creep.name}: role=${transferData.role}, room=${transferData.room}`);
 						
 						// Restore memory
 						creep.memory.role = transferData.role;
@@ -2071,12 +2071,12 @@
 							}
 						});
 						
-						console.log(`<font color="#4ECDC4">[Colonizer]</font> Memory restored for ${creep.name}: role=${creep.memory.role}, room=${creep.memory.room}`);
+						console.log(`[Colonizer] Memory restored for ${creep.name}: role=${creep.memory.role}, room=${creep.memory.room}`);
 				} else {
-						console.log(`<font color="#FFA500">[Colonizer]</font> ${creep.name} not found in master ISM creep_transfers`);
+						console.log(`[Colonizer] ${creep.name} not found in master ISM creep_transfers`);
 				}
 			} catch (e) {
-				console.log(`<font color="#FFA500">[Colonizer]</font> Error reading master ISM: ${e.message}`);
+				console.log(`[Colonizer] Error reading master ISM: ${e.message}`);
 			}
 		}
 		
@@ -2157,7 +2157,7 @@
 					
 					// Fallback: if no exact match, take first portal (for edge cases)
 					if (!portal && portals.length > 0) {
-						console.log(`<font color="#FFAA00">[Colonizer]</font> ${creep.name} no exact portal match for ${destShard}/${destRoom} in ${portalRoom}, using first available`);
+						console.log(`[Colonizer] ${creep.name} no exact portal match for ${destShard}/${destRoom} in ${portalRoom}, using first available`);
 						portal = portals[0];
 					}
 				}
@@ -2168,7 +2168,7 @@
 						destination_room: destRoom,
 						portal_pos: { x: portal.pos.x, y: portal.pos.y, roomName: portal.pos.roomName }
 					};
-					console.log(`<font color="#4ECDC4">[Colonizer]</font> ${creep.name} detected shard transition to ${destShard}/${destRoom}, portal at ${portalRoom}`);
+					console.log(`[Colonizer] ${creep.name} detected shard transition to ${destShard}/${destRoom}, portal at ${portalRoom}`);
 				}
 			}
 		}
@@ -2213,7 +2213,7 @@
 				
 				InterShardMemory.setLocal(JSON.stringify(ismData));
 				
-				console.log(`<font color="#4ECDC4">[Colonizer]</font> Transfer data stored for ${creep.name}`);
+				console.log(`[Colonizer] Transfer data stored for ${creep.name}`);
 				creep.memory.transfer_data_stored = true;
 			}
 			
@@ -2229,7 +2229,7 @@
 			// Check if creep is at portal
 			if (creep.pos.x === portalPos.x && creep.pos.y === portalPos.y && creep.room.name === portalPos.roomName) {
 				// Creep is at portal, transfer will happen automatically
-				console.log(`<font color="#4ECDC4">[Colonizer]</font> ${creep.name} at portal, transferring to ${creep.memory.transfer_intent.destination_shard}`);
+				console.log(`[Colonizer] ${creep.name} at portal, transferring to ${creep.memory.transfer_intent.destination_shard}`);
 				
 				// Clear transfer intent - the transfer will happen automatically
 				delete creep.memory.transfer_intent;
@@ -2253,7 +2253,7 @@
 					// Adjacent to portal - move onto it
 					let moveResult = creep.move(creep.pos.getDirectionTo(portalPos.x, portalPos.y));
 					if (moveResult === OK) {
-						console.log(`<font color="#4ECDC4">[Colonizer]</font> ${creep.name} crossing portal`);
+						console.log(`[Colonizer] ${creep.name} crossing portal`);
 					}
 					return;
 				} else {
@@ -2292,7 +2292,7 @@
 				_.set(Memory, ["rooms", creep.room.name, "layout"], _.get(request, "layout"));
 				_.set(Memory, ["rooms", creep.room.name, "focus_defense"], _.get(request, "focus_defense"));
 				_.set(Memory, ["hive", "pulses", "blueprint", "request"], creep.room.name);
-				console.log(`<font color="#4ECDC4">[Colonization]</font> ${creep.name} - first spawn complete, colonization mission complete!`);
+				console.log(`[Colonization] ${creep.name} - first spawn complete, colonization mission complete!`);
 				creep.memory = {};
 				return;
 			} else {
@@ -2303,7 +2303,7 @@
 					_.set(Memory, ["rooms", creep.room.name, "layout"], _.get(request, "layout"));
 					_.set(Memory, ["rooms", creep.room.name, "focus_defense"], _.get(request, "focus_defense"));
 					_.set(Memory, ["hive", "pulses", "blueprint", "request"], creep.room.name);
-					console.log(`<font color="#4ECDC4">[Colonization]</font> ${creep.room.name} - room claimed, waiting for first spawn...`);
+					console.log(`[Colonization] ${creep.room.name} - room claimed, waiting for first spawn...`);
 				}
 				// Colonizer can help build the spawn while waiting
 				creep.memory.state = "working";
@@ -2328,11 +2328,11 @@
 				_.set(Memory, ["rooms", creep.room.name, "focus_defense"], _.get(request, "focus_defense"));
 				_.set(Memory, ["hive", "pulses", "blueprint", "request"], creep.room.name);
 			}
-			console.log(`<font color="#4ECDC4">[Colonization]</font> ${creep.name} successfully claimed ${creep.room.name}! Waiting for first spawn...`);
+			console.log(`[Colonization] ${creep.name} successfully claimed ${creep.room.name}! Waiting for first spawn...`);
 			creep.memory.state = "working";
 			return;
 		} else {
-			console.log(`<font color=\"#F0FF00\">[Colonization]</font> ${creep.name} unable to colonize ${_.get(request, ["target"])}; error ${result}`);
+			console.log(`[Colonization] ${creep.name} unable to colonize ${_.get(request, ["target"])}; error ${result}`);
 			return;
 		}
 	},
@@ -2655,7 +2655,7 @@
 		if (carrySum === creep.carryCapacity && currentState !== "returning") {
 			currentState = "returning";
 			creep.memory.state = currentState;
-			console.log(`<font color=\"#FFA500\">[Highway]</font> Burrower ${creep.name} returning home from ${creep.room.name}`);
+			console.log(`[Highway] Burrower ${creep.name} returning home from ${creep.room.name}`);
 		} else if (carrySum === 0 && isInColony && currentState !== "mining") {
 			currentState = "mining";
 			creep.memory.state = currentState;
@@ -2701,7 +2701,7 @@
 			let target = Game.getObjectById(highwayData.resource_id);
 			if (!target || (target.structureType === "deposit" && target.ticksToDeposit <= 0)) {
 				highwayData.state = "completed";
-				console.log(`<font color=\"#FFA500\">[Highway]</font> Resource ${highwayData.resource_id} depleted or gone, marking operation as completed for ${creep.memory.highway_id}`);
+				console.log(`[Highway] Resource ${highwayData.resource_id} depleted or gone, marking operation as completed for ${creep.memory.highway_id}`);
 			}
 		}
 	},

--- a/definitions_creep_roles.js
+++ b/definitions_creep_roles.js
@@ -2252,17 +2252,36 @@
 		let reqTargetBase = _.isString(reqTarget) && reqTarget.indexOf("/") >= 0 ? reqTarget.split("/")[1] : reqTarget;
 		
 		if ((reqTarget == creep.room.name || reqTargetBase == creep.room.name) && creep.room.controller.my) {
-			// Room already claimed! Close colonization mission and set up the new colony
-			let key = creep.memory.target_key || creep.room.name;
-			delete Memory["sites"]["colonization"][key];
-			_.set(Memory, ["rooms", creep.room.name, "spawn_assist", "rooms"], [_.get(request, ["from"])]);
-			_.set(Memory, ["rooms", creep.room.name, "spawn_assist", "list_route"], _.get(request, ["list_route"]));
-			_.set(Memory, ["rooms", creep.room.name, "layout"], _.get(request, "layout"));
-			_.set(Memory, ["rooms", creep.room.name, "focus_defense"], _.get(request, "focus_defense"));
-			_.set(Memory, ["hive", "pulses", "blueprint", "request"], creep.room.name);
-			console.log(`<font color="#4ECDC4">[Colonization]</font> ${creep.name} - room already claimed, colonization mission complete!`);
-			creep.memory = {};
-			return;
+			// Room already claimed! Check if first spawn is built before completing mission
+			let spawns = creep.room.find(FIND_MY_SPAWNS);
+			
+			if (spawns.length > 0) {
+				// First spawn is complete! Close colonization mission
+				let key = creep.memory.target_key || creep.room.name;
+				delete Memory["sites"]["colonization"][key];
+				_.set(Memory, ["rooms", creep.room.name, "spawn_assist", "rooms"], [_.get(request, ["from"])]);
+				_.set(Memory, ["rooms", creep.room.name, "spawn_assist", "list_route"], _.get(request, ["list_route"]));
+				_.set(Memory, ["rooms", creep.room.name, "layout"], _.get(request, "layout"));
+				_.set(Memory, ["rooms", creep.room.name, "focus_defense"], _.get(request, "focus_defense"));
+				_.set(Memory, ["hive", "pulses", "blueprint", "request"], creep.room.name);
+				console.log(`<font color="#4ECDC4">[Colonization]</font> ${creep.name} - first spawn complete, colonization mission complete!`);
+				creep.memory = {};
+				return;
+			} else {
+				// Room claimed but no spawn yet - ensure spawn assist and layout are set but keep mission active
+				if (!_.get(Memory, ["rooms", creep.room.name, "spawn_assist", "rooms"])) {
+					_.set(Memory, ["rooms", creep.room.name, "spawn_assist", "rooms"], [_.get(request, ["from"])]);
+					_.set(Memory, ["rooms", creep.room.name, "spawn_assist", "list_route"], _.get(request, ["list_route"]));
+					_.set(Memory, ["rooms", creep.room.name, "layout"], _.get(request, "layout"));
+					_.set(Memory, ["rooms", creep.room.name, "focus_defense"], _.get(request, "focus_defense"));
+					_.set(Memory, ["hive", "pulses", "blueprint", "request"], creep.room.name);
+					console.log(`<font color="#4ECDC4">[Colonization]</font> ${creep.room.name} - room claimed, waiting for first spawn...`);
+				}
+				// Colonizer can help build the spawn while waiting
+				creep.memory.state = "working";
+				delete creep.memory.task;
+				return;
+			}
 		}
 
 		// Attempt to claim the controller
@@ -2273,16 +2292,16 @@
 		} else if (result == ERR_NO_BODYPART) {
 			return;		// Reservers and colonizers with no "claim" parts prevent null body spawn locking
 		} else if (result == OK) {
-			// Successfully claimed! Close the colonization mission
-			let key = creep.memory.target_key || creep.room.name;
-			delete Memory["sites"]["colonization"][key];
-			_.set(Memory, ["rooms", creep.room.name, "spawn_assist", "rooms"], [_.get(request, ["from"])]);
-			_.set(Memory, ["rooms", creep.room.name, "spawn_assist", "list_route"], _.get(request, ["list_route"]));
-			_.set(Memory, ["rooms", creep.room.name, "layout"], _.get(request, "layout"));
-			_.set(Memory, ["rooms", creep.room.name, "focus_defense"], _.get(request, "focus_defense"));
-			_.set(Memory, ["hive", "pulses", "blueprint", "request"], creep.room.name);
-			console.log(`<font color="#4ECDC4">[Colonization]</font> ${creep.name} successfully claimed ${creep.room.name}!`);
-			creep.memory = {};
+			// Successfully claimed! Set up spawn assist but keep mission active until spawn is built
+			if (!_.get(Memory, ["rooms", creep.room.name, "spawn_assist", "rooms"])) {
+				_.set(Memory, ["rooms", creep.room.name, "spawn_assist", "rooms"], [_.get(request, ["from"])]);
+				_.set(Memory, ["rooms", creep.room.name, "spawn_assist", "list_route"], _.get(request, ["list_route"]));
+				_.set(Memory, ["rooms", creep.room.name, "layout"], _.get(request, "layout"));
+				_.set(Memory, ["rooms", creep.room.name, "focus_defense"], _.get(request, "focus_defense"));
+				_.set(Memory, ["hive", "pulses", "blueprint", "request"], creep.room.name);
+			}
+			console.log(`<font color="#4ECDC4">[Colonization]</font> ${creep.name} successfully claimed ${creep.room.name}! Waiting for first spawn...`);
+			creep.memory.state = "working";
 			return;
 		} else {
 			console.log(`<font color=\"#F0FF00\">[Colonization]</font> ${creep.name} unable to colonize ${_.get(request, ["target"])}; error ${result}`);

--- a/definitions_global_creeps.js
+++ b/definitions_global_creeps.js
@@ -90,7 +90,7 @@ global.GlobalCreeps = {
 			default:
 				// Unknown role - log warning
 				if (Game.time % 100 === 0) {
-					console.log(`<font color="#FFA500">[GlobalCreeps]</font> Unknown role for global creep ${creep.name}: ${role}`);
+					console.log(`[GlobalCreeps] Unknown role for global creep ${creep.name}: ${role}`);
 				}
 				break;
 		}
@@ -329,7 +329,7 @@ global.GlobalCreeps = {
 					discovered: Game.time
 				};
 				
-				console.log(`<font color="#FFFF00">[Resources]</font> Found power bank in ${roomName}: ${bank.power} power`);
+				console.log(`[Resources] Found power bank in ${roomName}: ${bank.power} power`);
 			});
 		}
 		
@@ -348,7 +348,7 @@ global.GlobalCreeps = {
 					discovered: Game.time
 				};
 				
-				console.log(`<font color="#FFFF00">[Resources]</font> Found ${deposit.depositType} deposit in ${roomName}`);
+				console.log(`[Resources] Found ${deposit.depositType} deposit in ${roomName}`);
 			});
 		}
 		

--- a/definitions_hive_control.js
+++ b/definitions_hive_control.js
@@ -1259,6 +1259,20 @@
 
 		Stats_CPU.Start("Hive", "processSpawnRequests");
 
+		// Merge global spawn requests into shard spawn queue (for cross-shard dispatched requests)
+		let globalRequests = _.get(Memory, ["hive", "spawn_requests"], []);
+		let shardRequests = _.get(Memory, ["shard", "spawn_requests"], []);
+		if (globalRequests.length > 0) {
+			_.each(globalRequests, req => {
+				if (req) {
+					shardRequests.push(req);
+				}
+			});
+			// Clear global queue after merging
+			Memory.hive.spawn_requests = [];
+			_.set(Memory, ["shard", "spawn_requests"], shardRequests);
+		}
+
 		// Cache spawn requests to avoid repeated memory lookups
 		let spawnRequests = _.get(Memory, ["shard", "spawn_requests"]);
 		if (!spawnRequests || spawnRequests.length == 0) {

--- a/definitions_hive_control.js
+++ b/definitions_hive_control.js
@@ -7,7 +7,7 @@
 	refillBucket: function () {
 		if (Game.cpu.bucket >= 10000 && _.get(Memory, ["shard", "pause", "bucket"], false)) {
 			_.set(Memory, ["shard", "pause", "bucket"], false);
-			console.log(`<font color=\"#D3FFA3\">[Console]</font> Bucket full, resuming main.js.`);
+			console.log(`[Console] Bucket full, resuming main.js.`);
 		}
 
 		return _.get(Memory, ["shard", "pause", "bucket"], false) || _.get(Memory, ["hive", "global_pause"], false);
@@ -85,7 +85,7 @@
 		try {
 			state.payloads[Game.shard.name] = ShardMemory.getLocalPayload();
 		} catch (err) {
-			console.log(`<font color="#FF6B6B">[InterShard]</font> Failed to read local payload: ${err.message}`);
+			console.log(`[InterShard] Failed to read local payload: ${err.message}`);
 		}
 
 		_.each(state.shards, shard => {
@@ -96,7 +96,7 @@
 				if (payload)
 					state.payloads[shard] = payload;
 			} catch (err) {
-				console.log(`<font color="#FF6B6B">[InterShard]</font> Failed to read remote payload ${shard}: ${err.message}`);
+				console.log(`[InterShard] Failed to read remote payload ${shard}: ${err.message}`);
 			}
 		});
 
@@ -303,7 +303,7 @@
 					try {
 						ShardMemory.removeGlobalCreep(name, "dead");
 					} catch (err) {
-						console.log(`<font color="#FF944E">[Shard]</font> Failed to unregister ${name}: ${err.message}`);
+						console.log(`[Shard] Failed to unregister ${name}: ${err.message}`);
 					}
 				});
 			}
@@ -327,7 +327,7 @@
 							let crossShard = destinationShard && destinationShard !== Game.shard.name;
 							if (!(crossShard && recentTransfer)) {
 								if (Memory && _.get(Memory, ["hive", "ism", "debug_transfers"])) {
-									console.log(`<font color="#9B5DE5">[InterShard]</font> clearDeadMemory removing transfer ${name}; crossShard=${crossShard} destination=${destinationShard} transferTime=${transferTime} recent=${recentTransfer}`);
+									console.log(`[InterShard] clearDeadMemory removing transfer ${name}; crossShard=${crossShard} destination=${destinationShard} transferTime=${transferTime} recent=${recentTransfer}`);
 								}
 								delete payload.creep_transfers[name];
 								changed = true;
@@ -350,7 +350,7 @@
 						InterShardMemory.setLocal(JSON.stringify(payload));
 				}
 			} catch (err) {
-				console.log(`<font color="#FF944E">[Shard]</font> Failed to prune ISM for dead creeps: ${err.message}`);
+				console.log(`[Shard] Failed to prune ISM for dead creeps: ${err.message}`);
 			}
 
 			let manifest = _.get(Memory, ["hive", "ism", "global", "local_manifest"]);
@@ -571,7 +571,7 @@
 		// Only log colonizer detection once per minute to reduce console spam
 		let colonizer_creeps = _.filter(creeps, c => c && (c.memory.role === "colonizer" || (typeof c.name === "string" && c.name.indexOf("colo:") === 0)));
 		if (colonizer_creeps.length > 0 && Game.time % 50 === 0) {
-			console.log(`<font color="#4ECDC4">[Colonizers]</font> ${colonizer_creeps.length} active on ${Game.shard.name}`);
+			console.log(`[Colonizers] ${colonizer_creeps.length} active on ${Game.shard.name}`);
 		}
 
 		_.each(creeps, creep => {
@@ -591,7 +591,7 @@
 			if (!needsRestoration && creep.memory.role === "colonizer" && !creep.memory.room && creep.name.startsWith('colo:')) {
 				// Transferred creep with role set but missing room - definitely needs ISM restoration
 				needsRestoration = true;
-				console.log(`<font color="#FFA500">[Colonizer]</font> ${creep.name} detected as transferred (role set, room missing)`);
+				console.log(`[Colonizer] ${creep.name} detected as transferred (role set, room missing)`);
 			}
 
 			if (needsRestoration) {
@@ -617,11 +617,11 @@
 					creep.memory.transferred = true;
 					creep.memory.transfer_time = transferData.transfer_time;
 					creep.memory.global_status = 'restored';
-					console.log(`<font color="#4ECDC4">[Colonizer]</font> ${creep.name} restored on ${creep.memory.room}`);
+					console.log(`[Colonizer] ${creep.name} restored on ${creep.memory.room}`);
 					role = creep.memory.role; // Update local role variable
 				}
 			} catch (e) {
-				console.log(`<font color="#FFA500">[Colonizer]</font> Error restoring ${creep.name}: ${e.message}`);
+				console.log(`[Colonizer] Error restoring ${creep.name}: ${e.message}`);
 			}
 		}
 
@@ -756,7 +756,7 @@
 					// Creep is dead or no longer tracked
 					let debugScouts = _.get(Memory, ["hive", "debug", "scout"], 0);
 					if (debugScouts >= 1) {
-						console.log(`<font color="#FF944E">[Scout]</font> Detected dead remote scout ${name} (last seen ${Game.time - lastSeen} ticks ago)`);
+						console.log(`[Scout] Detected dead remote scout ${name} (last seen ${Game.time - lastSeen} ticks ago)`);
 					}
 					delete request.remote_creeps[name];
 					request._remote_pruned++;
@@ -1051,7 +1051,7 @@
 				route.push(destination);
 			}
 		} catch (error) {
-			console.log(`<font color=\"#FF944E\">[Scout]</font> Unable to derive route ${origin} -> ${destination}: ${error}`);
+			console.log(`[Scout] Unable to derive route ${origin} -> ${destination}: ${error}`);
 			if (_.last(route) !== destination)
 				route.push(destination);
 		}
@@ -1097,7 +1097,7 @@
 								// Clear dispatched requests for this shard
 								if (dispatched[shard]) {
 									delete dispatched[shard];
-									console.log(`<font color="#4ECDC4">[CrossShard]</font> Cleared dispatched requests for ${shard}`);
+									console.log(`[CrossShard] Cleared dispatched requests for ${shard}`);
 								}
 							}
 						}
@@ -1111,7 +1111,7 @@
 				InterShardMemory.setLocal(JSON.stringify(localParsed));
 			}
 		} catch (err) {
-			console.log(`<font color="#FF6B6B">[CrossShard]</font> Failed to process clear requests: ${err.message}`);
+			console.log(`[CrossShard] Failed to process clear requests: ${err.message}`);
 		}
 
 		// Read spawn requests from all shards
@@ -1138,7 +1138,7 @@
 					});
 				}
 			} catch (err) {
-				console.log(`<font color="#FF6B6B">[CrossShard]</font> Failed to read spawn requests from ${shard}: ${err.message}`);
+				console.log(`[CrossShard] Failed to read spawn requests from ${shard}: ${err.message}`);
 			}
 		});
 
@@ -1194,7 +1194,7 @@
 
 					InterShardMemory.setLocal(JSON.stringify(localParsed));
 				} catch (err) {
-					console.log(`<font color="#FF6B6B">[CrossShard]</font> Failed to dispatch spawn request to ${targetShard}: ${err.message}`);
+					console.log(`[CrossShard] Failed to dispatch spawn request to ${targetShard}: ${err.message}`);
 				}
 			}
 		});
@@ -1243,7 +1243,7 @@
 								Memory.hive.spawn_requests.push(req);
 						});
 
-						console.log(`<font color="#4ECDC4">[CrossShard]</font> Received ${dispatched.length} spawn requests from master shard0`);
+						console.log(`[CrossShard] Received ${dispatched.length} spawn requests from master shard0`);
 
 						// Clear dispatched requests from master ISM by notifying master
 						let localData = InterShardMemory.getLocal();
@@ -1253,7 +1253,7 @@
 					}
 				}
 			} catch (err) {
-				console.log(`<font color="#FF6B6B">[CrossShard]</font> Failed to read dispatched spawn requests: ${err.message}`);
+				console.log(`[CrossShard] Failed to read dispatched spawn requests: ${err.message}`);
 			}
 		}
 
@@ -1424,7 +1424,7 @@
 				: bestSpawn.spawnCreep(body, name, { memory: request.args, energyStructures: energies });
 
 			if (result == OK) {
-				console.log(`<font color=\"#19C800\">[Spawns]</font> Spawning `
+				console.log(`[Spawns] Spawning `
 					+ (bestSpawn.room.name == room ? `${room}  ` : `${bestSpawn.room.name} -> ${room}  `)
 					+ `${level} / ${request.level}  ${name} : ${request.args["role"]}`
 					+ `${request.args["subrole"] == null ? "" : ", " + request.args["subrole"]} `
@@ -1510,7 +1510,7 @@
 
 				if (order != null) {
 					if (_.get(Memory, ["resources", "terminal_orders", `overflow_${res}`]) != null)
-						console.log(`<font color=\"#F7FF00\">[Hive]</font> Selling overflow resource to market: ${excess} of ${res} from ${room}`);
+						console.log(`[Hive] Selling overflow resource to market: ${excess} of ${res} from ${room}`);
 					_.set(Memory, ["resources", "terminal_orders", `overflow_${res}`], { market_id: order.id, amount: excess, from: room, priority: 4 });
 
 				}
@@ -1545,7 +1545,7 @@
 				r => { return !_.has(Memory, ["resources", "terminal_orders", `overflow_energy_${r}`]) && energy[r] - limit > 100; }),
 				r => {	// Terminal transfers: minimum quantity of 100.
 					_.set(Memory, ["resources", "terminal_orders", `overflow_energy_${r}`], { room: tgtRoom, resource: "energy", amount: energy[r] - limit, from: r, priority: 2 });
-					console.log(`<font color=\"#F7FF00\">[Hive]</font> Creating overflow energy transfer: ${energy[r] - limit}, ${r} -> ${tgtRoom}`);
+					console.log(`[Hive] Creating overflow energy transfer: ${energy[r] - limit}, ${r} -> ${tgtRoom}`);
 				});
 		}
 
@@ -1600,7 +1600,7 @@
 					r => { return r.controller != null && r.controller.my && r.terminal; }),
 					r => { amount += r.store(reagent); });
 				if (amount <= 1000 && !_.has(Memory, ["resources", "labs", "targets", reagent]) && getReagents(reagent) != null) {
-					console.log(`<font color=\"#A17BFF\">[Labs]</font> reagent ${reagent} missing for ${target.mineral}, creating target goal.`);
+					console.log(`[Labs] reagent ${reagent} missing for ${target.mineral}, creating target goal.`);
 					Memory["resources"]["labs"]["targets"][reagent] = { amount: target.amount, priority: target.priority, mineral: reagent, is_reagent: true };
 					this.createReagentTargets(Memory["resources"]["labs"]["targets"][reagent]);
 				}
@@ -1658,9 +1658,9 @@
 					Memory.hive.pixels.stats.generation_history.shift();
 				}
 				
-				console.log(`<font color=\"#FFD700\">[Pixels]</font> Generated pixel! Total: ${Memory.hive.pixels.stats.total_generated}, CPU: ${(cpuUsagePercent * 100).toFixed(1)}%, Bucket: ${Game.cpu.bucket}`);
+				console.log(`[Pixels] Generated pixel! Total: ${Memory.hive.pixels.stats.total_generated}, CPU: ${(cpuUsagePercent * 100).toFixed(1)}%, Bucket: ${Game.cpu.bucket}`);
 			} else {
-				console.log(`<font color=\"#FF6B6B\">[Pixels]</font> Failed to generate pixel. Error code: ${result}`);
+				console.log(`[Pixels] Failed to generate pixel. Error code: ${result}`);
 			}
 		}
 	},

--- a/definitions_intershard.js
+++ b/definitions_intershard.js
@@ -166,7 +166,7 @@ global.ShardMemory = {
 			global._localPayloadCacheTick = Game.time;
 			return payload;
 		} catch (err) {
-			console.log(`<font color="#FF6B6B">[InterShard]</font> Failed to parse local payload: ${err.message}`);
+			console.log(`[InterShard] Failed to parse local payload: ${err.message}`);
 			return this._bootstrapPayload();
 		}
 	},
@@ -184,7 +184,7 @@ global.ShardMemory = {
 			try {
 				mutator(payload);
 			} catch (err) {
-				console.log(`<font color="#FF6B6B">[InterShard]</font> updateLocal mutator error: ${err.message}`);
+				console.log(`[InterShard] updateLocal mutator error: ${err.message}`);
 			}
 		}
 
@@ -221,7 +221,7 @@ global.ShardMemory = {
 			let parsed = JSON.parse(raw);
 			return this._coercePayload(parsed);
 		} catch (err) {
-			console.log(`<font color="#FF6B6B">[InterShard]</font> Failed to parse remote payload (${shardName}): ${err.message}`);
+			console.log(`[InterShard] Failed to parse remote payload (${shardName}): ${err.message}`);
 			return null;
 		}
 	},
@@ -859,7 +859,7 @@ global.ShardMemory = {
 		}
 
 		if (json.length > this.MAX_SERIALIZED_LENGTH) {
-			console.log(`<font color="#FF6B6B">[InterShard]</font> Payload still exceeds size limit (${json.length}) after trimming; dropping history.`);
+			console.log(`[InterShard] Payload still exceeds size limit (${json.length}) after trimming; dropping history.`);
 			if (_.has(toSerialize, ["global", "history"])) {
 				toSerialize.global.history = [];
 				json = JSON.stringify(toSerialize);
@@ -994,7 +994,7 @@ global.ShardMemory = {
 			}
 			
 			if (removed.length > 0) {
-				console.log(`<font color="#FFD700">[InterShard]</font> Cleanup: Removed ${removed.length} old creeps from manifest`);
+				console.log(`[InterShard] Cleanup: Removed ${removed.length} old creeps from manifest`);
 			}
 		});
 	}

--- a/definitions_intershard_lean.js
+++ b/definitions_intershard_lean.js
@@ -298,7 +298,7 @@ global.ShardMemory = {
 			try {
 				mutator(payload);
 			} catch (err) {
-				console.log(`<font color="#FF6B6B">[InterShard]</font> updateLocal error: ${err.message}`);
+				console.log(`[InterShard] updateLocal error: ${err.message}`);
 			}
 		}
 
@@ -335,7 +335,7 @@ global.ShardMemory = {
 			let parsed = JSON.parse(raw);
 			return this._coercePayload(parsed);
 		} catch (err) {
-			console.log(`<font color="#FF6B6B">[InterShard]</font> Failed to parse remote (${shardName}): ${err.message}`);
+			console.log(`[InterShard] Failed to parse remote (${shardName}): ${err.message}`);
 			return null;
 		}
 	},
@@ -374,7 +374,7 @@ global.ShardMemory = {
 			global._localPayloadCacheTick = Game.time;
 			return payload;
 		} catch (err) {
-			console.log(`<font color="#FF6B6B">[InterShard]</font> Parse error: ${err.message}`);
+			console.log(`[InterShard] Parse error: ${err.message}`);
 			return this._bootstrapPayload();
 		}
 	},
@@ -517,7 +517,7 @@ global.ShardMemory = {
 		}
 
 		if (json.length > this.MAX_SERIALIZED_LENGTH) {
-			console.log(`<font color="#FF6B6B">[InterShard]</font> WARNING: Payload exceeds limit (${json.length}b)`);
+			console.log(`[InterShard] WARNING: Payload exceeds limit (${json.length}b)`);
 		}
 
 		InterShardMemory.setLocal(json);

--- a/definitions_intershard_memory.js
+++ b/definitions_intershard_memory.js
@@ -103,11 +103,11 @@ global.ISM = {
 			_.set(Memory, ["shard", "ism_size"], ismSize);
 			
 			if (ismSize > 90000) {
-				console.log(`<font color="#FF0000">[ISM]</font> WARNING: ISM size ${ismSize} bytes approaching 100KB limit!`);
+				console.log(`[ISM] WARNING: ISM size ${ismSize} bytes approaching 100KB limit!`);
 			}
 			
 		} catch (err) {
-			console.log(`<font color="#FF0000">[ISM]</font> Error publishing status: ${err.message}`);
+			console.log(`[ISM] Error publishing status: ${err.message}`);
 		}
 	},
 
@@ -128,7 +128,7 @@ global.ISM = {
 			}
 			return JSON.parse(data);
 		} catch (err) {
-			console.log(`<font color="#FF0000">[ISM]</font> Error reading shard ${shardName}: ${err.message}`);
+			console.log(`[ISM] Error reading shard ${shardName}: ${err.message}`);
 			return null;
 		}
 	},
@@ -152,7 +152,7 @@ global.ISM = {
 				statuses[currentShard] = JSON.parse(localData);
 			}
 		} catch (err) {
-			console.log(`<font color="#FF0000">[ISM]</font> Error reading local ISM: ${err.message}`);
+			console.log(`[ISM] Error reading local ISM: ${err.message}`);
 		}
 
 		// Try to read from other known shards
@@ -191,41 +191,41 @@ global.ISM = {
 	 */
 	debug: function() {
 		if (!this.isAvailable()) {
-			console.log("<font color='#FF0000'>[ISM]</font> InterShardMemory not available");
+			console.log("[ISM] InterShardMemory not available");
 			return;
 		}
 
 		try {
 			let localData = InterShardMemory.getLocal();
 			let size = localData ? localData.length : 0;
-			console.log(`<font color='#00FFFF'>[ISM]</font> Local ISM Size: ${size} / 102400 bytes (${(size/1024).toFixed(2)} KB)`);
+			console.log(`[ISM] Local ISM Size: ${size} / 102400 bytes (${(size/1024).toFixed(2)} KB)`);
 			
 			if (localData && localData !== "") {
 				let parsed = JSON.parse(localData);
-				console.log(`<font color='#00FFFF'>[ISM]</font> Shard: ${parsed.shard_name}, Tick: ${parsed.tick}`);
-				console.log(`<font color='#00FFFF'>[ISM]</font> Colonies: ${Object.keys(parsed.colonies || {}).length}`);
-				console.log(`<font color='#00FFFF'>[ISM]</font> Energy: ${(_.get(parsed, ["resources", "energy"], 0)).toLocaleString()}`);
-				console.log(`<font color='#00FFFF'>[ISM]</font> Operations: ${(_.get(parsed, ["operations", "colonizations", "length"], 0))} colonizations, ${(_.get(parsed, ["operations", "creep_transfers", "length"], 0))} transfers`);
+				console.log(`[ISM] Shard: ${parsed.shard_name}, Tick: ${parsed.tick}`);
+				console.log(`[ISM] Colonies: ${Object.keys(parsed.colonies || {}).length}`);
+				console.log(`[ISM] Energy: ${(_.get(parsed, ["resources", "energy"], 0)).toLocaleString()}`);
+				console.log(`[ISM] Operations: ${(_.get(parsed, ["operations", "colonizations", "length"], 0))} colonizations, ${(_.get(parsed, ["operations", "creep_transfers", "length"], 0))} transfers`);
 			}
 			
 			// Try to read other shards
 			let knownShards = ["shard0", "shard1", "shard2", "shard3"];
 			let currentShard = _.get(Game, ["shard", "name"], "sim");
 			
-			console.log(`<font color='#00FFFF'>[ISM]</font> --- Other Shards ---`);
+			console.log(`[ISM] --- Other Shards ---`);
 			_.each(knownShards, shardName => {
 				if (shardName !== currentShard) {
 					let status = this.getShardStatus(shardName);
 					if (status) {
-						console.log(`<font color='#00FFFF'>[ISM]</font> ${shardName}: ${Object.keys(status.colonies || {}).length} colonies, ${(_.get(status, ["resources", "energy"], 0)).toLocaleString()} energy`);
+						console.log(`[ISM] ${shardName}: ${Object.keys(status.colonies || {}).length} colonies, ${(_.get(status, ["resources", "energy"], 0)).toLocaleString()} energy`);
 					} else {
-						console.log(`<font color='#00FFFF'>[ISM]</font> ${shardName}: No data`);
+						console.log(`[ISM] ${shardName}: No data`);
 					}
 				}
 			});
 			
 		} catch (err) {
-			console.log(`<font color="#FF0000">[ISM]</font> Error in debug: ${err.message}`);
+			console.log(`[ISM] Error in debug: ${err.message}`);
 		}
 	}
 };

--- a/definitions_portals.js
+++ b/definitions_portals.js
@@ -69,7 +69,7 @@ global.Portals = {
 		});
 
 		if (portalsFound > 0) {
-			console.log(`<font color="#00FFFF">[Portals]</font> Detected ${portalsFound} portal(s) across ${Object.keys(Game.rooms).length} visible rooms`);
+			console.log(`[Portals] Detected ${portalsFound} portal(s) across ${Object.keys(Game.rooms).length} visible rooms`);
 		}
 
 		Stats_CPU.End("Portals", "scanPortals");
@@ -158,7 +158,7 @@ global.Portals = {
 		let portals = this.getPortalsToShard(destShard);
 		
 		if (portals.length === 0) {
-			console.log(`<font color="#FF0000">[Portals]</font> No portals found to shard ${destShard}`);
+			console.log(`[Portals] No portals found to shard ${destShard}`);
 			return null;
 		}
 
@@ -170,13 +170,13 @@ global.Portals = {
 		
 		// Log portal availability status (but don't treat it as an error)
 		if (viablePortals.length === 0 && portals.length > 0) {
-			console.log(`<font color="#FFA500">[Portals]</font> Found ${portals.length} portal(s) to shard ${destShard}, checking stability...`);
+			console.log(`[Portals] Found ${portals.length} portal(s) to shard ${destShard}, checking stability...`);
 		}
 
 		// If no "stable" portals found, use any portal for testing
 		if (viablePortals.length === 0) {
 			viablePortals = portals;
-			console.log(`<font color="#FFA500">[Portals]</font> No explicitly stable portals to shard ${destShard}, using available portals for cross-shard travel`);
+			console.log(`[Portals] No explicitly stable portals to shard ${destShard}, using available portals for cross-shard travel`);
 		}
 
 		// Find nearest viable portal
@@ -193,7 +193,7 @@ global.Portals = {
 		});
 
 		if (!nearest) {
-			console.log(`<font color="#FF0000">[Portals]</font> No path to any portal from ${sourceRoom}`);
+			console.log(`[Portals] No path to any portal from ${sourceRoom}`);
 			return null;
 		}
 
@@ -263,7 +263,7 @@ global.Portals = {
 
 		Memory.shard.operations.creep_transfers.push(transfer);
 		
-		console.log(`<font color="#00FFFF">[Portals]</font> Tracking ${creepName} transfer to ${destShard}/${destRoom} (ETA: ${expectedTick - Game.time} ticks)`);
+		console.log(`[Portals] Tracking ${creepName} transfer to ${destShard}/${destRoom} (ETA: ${expectedTick - Game.time} ticks)`);
 	},
 
 	/**
@@ -305,7 +305,7 @@ global.Portals = {
 				}
 
 				if (role) {
-					console.log(`<font color="#FFA500">[Portals]</font> Restoring lost memory for ${creep.name} (detected as ${role}) in ${roomName}`);
+					console.log(`[Portals] Restoring lost memory for ${creep.name} (detected as ${role}) in ${roomName}`);
 
 					// Restore basic memory
 					creep.memory.role = role;
@@ -364,7 +364,7 @@ global.Portals = {
 					
 					if (creep) {
 						// Creep has arrived!
-						console.log(`<font color="#00FF00">[Portals]</font> Creep ${transfer.creep_name} arrived from ${otherShard} to ${transfer.dest_room}`);
+						console.log(`[Portals] Creep ${transfer.creep_name} arrived from ${otherShard} to ${transfer.dest_room}`);
 						
 						// Restore preserved memory
 						if (transfer.memory) {
@@ -385,7 +385,7 @@ global.Portals = {
 						
 						// Auto-reset scouts to exploration mode when they arrive on a new shard
 						if (creep.memory.role === "portal_scout") {
-							console.log(`<font color="#00FFFF">[Portals]</font> Auto-resetting scout ${transfer.creep_name} to exploration mode on ${currentShard}`);
+							console.log(`[Portals] Auto-resetting scout ${transfer.creep_name} to exploration mode on ${currentShard}`);
 							creep.memory.test_mode = false;
 							creep.memory.portal_target_shard = undefined;
 							creep.memory.portal_target_room = undefined;
@@ -406,7 +406,7 @@ global.Portals = {
 						let expectedTime = transfer.expected_arrival_tick - transfer.departure_tick;
 						
 						if (Game.time > transfer.expected_arrival_tick + 500) {
-							console.log(`<font color="#FF0000">[Portals]</font> Creep ${transfer.creep_name} from ${otherShard} timed out after ${travelTime} ticks (expected ${expectedTime})`);
+							console.log(`[Portals] Creep ${transfer.creep_name} from ${otherShard} timed out after ${travelTime} ticks (expected ${expectedTime})`);
 							timeoutsDetected++;
 						}
 					}
@@ -425,7 +425,7 @@ global.Portals = {
 			
 			// Log cleanup
 			if (!keepTransfer && Game.time >= transfer.expected_arrival_tick + 1000) {
-				console.log(`<font color="#FF6600">[Portals]</font> Cleaning up timed-out transfer: ${transfer.creep_name} to ${transfer.dest_shard}`);
+				console.log(`[Portals] Cleaning up timed-out transfer: ${transfer.creep_name} to ${transfer.dest_shard}`);
 			}
 			
 			return keepTransfer;
@@ -440,7 +440,7 @@ global.Portals = {
 			if (restoredCreeps > 0) parts.push(`${restoredCreeps} restored`);
 			if (timeoutsDetected > 0) parts.push(`${timeoutsDetected} timeouts`);
 			if (cleanedCount > 0) parts.push(`${cleanedCount} cleaned`);
-			console.log(`<font color="#00FFFF">[Portals]</font> Arrival processing: ${parts.join(", ")}`);
+			console.log(`[Portals] Arrival processing: ${parts.join(", ")}`);
 		}
 
 		Stats_CPU.End("Portals", "processArrivals");
@@ -453,11 +453,11 @@ global.Portals = {
 		let portals = this.getAll();
 		
 		if (portals.length === 0) {
-			console.log("<font color='#00FFFF'>[Portals]</font> No portals detected yet. Scan will run on next long pulse.");
+			console.log("[Portals] No portals detected yet. Scan will run on next long pulse.");
 			return;
 		}
 
-		console.log(`<font color='#00FFFF'>[Portals]</font> === Known Portals (${portals.length}) ===`);
+		console.log(`[Portals] === Known Portals (${portals.length}) ===`);
 		
 		// Group by destination shard
 		let byShard = {};
@@ -470,11 +470,11 @@ global.Portals = {
 		});
 
 		_.each(Object.keys(byShard), shard => {
-			console.log(`<font color='#00FFFF'>[Portals]</font> → ${shard}:`);
+			console.log(`[Portals] → ${shard}:`);
 			_.each(byShard[shard], portal => {
 				let stability = portal.stable ? "stable" : `unstable (${portal.ticksToDecay} ticks)`;
 				let age = Game.time - portal.lastSeen;
-				console.log(`<font color='#00FFFF'>[Portals]</font>   ${portal.pos.roomName} → ${portal.destination.room} (${stability}, seen ${age} ticks ago)`);
+				console.log(`[Portals]   ${portal.pos.roomName} → ${portal.destination.room} (${stability}, seen ${age} ticks ago)`);
 			});
 		});
 	},

--- a/definitions_shard_control.js
+++ b/definitions_shard_control.js
@@ -166,7 +166,8 @@ global.ShardControl = {
 		let ackCount = 0;
 
 	if (directiveForFollower) {
-		let pending = _.get(directiveForFollower, ["handshake", "pending"], {});
+		// Read from 'pending_handshakes' to match primary's write path
+		let pending = _.get(directiveForFollower, "pending_handshakes", {});
 		
 		_.each(pending, (entry, creepName) => {
 				if (!entry)

--- a/definitions_shard_control.js
+++ b/definitions_shard_control.js
@@ -108,7 +108,7 @@ global.ShardControl = {
 		});
 		
 		if (handshakeCount > 0) {
-			console.log(`<font color="#4ECDC4">[InterShard]</font> PRIMARY: Distributed ${handshakeCount} handshake offers`);
+			console.log(`[InterShard] PRIMARY: Distributed ${handshakeCount} handshake offers`);
 		}
 
 		// Process acknowledgments from follower shards and complete handshakes
@@ -136,13 +136,13 @@ global.ShardControl = {
 					delete payload.handshake.pending[creepName];
 					acksProcessed++;
 					
-					console.log(`<font color="#4ECDC4">[InterShard]</font> PRIMARY: Completed handshake for ${creepName}`);
+					console.log(`[InterShard] PRIMARY: Completed handshake for ${creepName}`);
 				}
 			});
 		});
 		
 		if (acksProcessed > 0) {
-			console.log(`<font color="#4ECDC4">[InterShard]</font> PRIMARY: Processed ${acksProcessed} acknowledgments`);
+			console.log(`[InterShard] PRIMARY: Processed ${acksProcessed} acknowledgments`);
 		}
 	}
 
@@ -157,7 +157,7 @@ global.ShardControl = {
 		let primaryPayload = ShardMemory.readPrimary();
 
 		if (!primaryPayload) {
-			console.log(`<font color="#FF6B6B">[InterShard]</font> FOLLOWER: No primary payload found!`);
+			console.log(`[InterShard] FOLLOWER: No primary payload found!`);
 			_.set(Memory, ["hive", "ism", "last_primary_seen"], null);
 			return;
 		}
@@ -196,13 +196,13 @@ global.ShardControl = {
 					transfer_data: transferData
 				});
 				ackCount++;
-				console.log(`<font color="#4ECDC4">[InterShard]</font> FOLLOWER: Acknowledged transfer for ${creepName}`);
+				console.log(`[InterShard] FOLLOWER: Acknowledged transfer for ${creepName}`);
 			}
 		});
 	}
 	
 	if (ackCount > 0) {
-		console.log(`<font color="#4ECDC4">[InterShard]</font> FOLLOWER: Sent ${ackCount} acknowledgements`);
+		console.log(`[InterShard] FOLLOWER: Sent ${ackCount} acknowledgements`);
 	}
 
 		_.set(Memory, ["hive", "ism", "follower_snapshot"], {

--- a/definitions_shard_coordinator.js
+++ b/definitions_shard_coordinator.js
@@ -152,7 +152,7 @@ global.ShardCoordinator = {
 				
 				if (allSpawned && op.creeps && op.creeps.length > 0) {
 					op.status = "traveling";
-					console.log(`<font color="#00FF00">[ShardCoordinator]</font> Colonization ${op.id}: All creeps spawned, now traveling`);
+					console.log(`[ShardCoordinator] Colonization ${op.id}: All creeps spawned, now traveling`);
 				}
 			}
 			
@@ -168,7 +168,7 @@ global.ShardCoordinator = {
 			
 			// Timeout check
 			if (age > 10000) {
-				console.log(`<font color="#FF0000">[ShardCoordinator]</font> Colonization ${op.id} timed out after ${age} ticks`);
+				console.log(`[ShardCoordinator] Colonization ${op.id} timed out after ${age} ticks`);
 				op.status = "failed";
 			}
 		});
@@ -193,7 +193,7 @@ global.ShardCoordinator = {
 			
 			// Timeout check
 			if (Game.time > transfer.expected_arrival_tick + 1000) {
-				console.log(`<font color="#FF0000">[ShardCoordinator]</font> Transfer ${transfer.id} timed out`);
+				console.log(`[ShardCoordinator] Transfer ${transfer.id} timed out`);
 				transfer.status = "failed";
 			}
 		});
@@ -213,7 +213,7 @@ global.ShardCoordinator = {
 	 */
 	planColonization: function(targetShard, targetRoom, options = {}) {
 		if (!Game.shard) {
-			console.log("<font color='#FF0000'>[ShardCoordinator]</font> Not on multi-shard server");
+			console.log("[ShardCoordinator] Not on multi-shard server");
 			return null;
 		}
 
@@ -224,7 +224,7 @@ global.ShardCoordinator = {
 		let route = Portals.getPortalRoute(sourceRoom, targetShard, targetRoom);
 		
 		if (!route) {
-			console.log(`<font color='#FF0000'>[ShardCoordinator]</font> No portal route found to ${targetShard}`);
+			console.log(`[ShardCoordinator] No portal route found to ${targetShard}`);
 			return null;
 		}
 
@@ -249,7 +249,7 @@ global.ShardCoordinator = {
 		}
 		Memory.shard.operations.colonizations.push(operation);
 
-		console.log(`<font color="#00FF00">[ShardCoordinator]</font> Colonization planned: ${targetShard}/${targetRoom} via ${route.portal.pos.roomName}`);
+		console.log(`[ShardCoordinator] Colonization planned: ${targetShard}/${targetRoom} via ${route.portal.pos.roomName}`);
 		
 		return opId;
 	},
@@ -259,11 +259,11 @@ global.ShardCoordinator = {
 	 */
 	displayStatus: function() {
 		if (!Game.shard) {
-			console.log("<font color='#FF0000'>[ShardCoordinator]</font> Not on multi-shard server");
+			console.log("[ShardCoordinator] Not on multi-shard server");
 			return;
 		}
 
-		console.log(`<font color='#00FFFF'>[ShardCoordinator]</font> === Multi-Shard Status ===`);
+		console.log(`[ShardCoordinator] === Multi-Shard Status ===`);
 		
 		let allStatuses = this.getAllShardStatuses();
 		
@@ -278,9 +278,9 @@ global.ShardCoordinator = {
 			
 			let current = (Game.shard.name === shardName) ? " (current)" : "";
 			
-			console.log(`<font color='#00FFFF'>[ShardCoordinator]</font> ${shardName}${current}:`);
-			console.log(`<font color='#00FFFF'>[ShardCoordinator]</font>   Colonies: ${colonies}, Energy: ${energy.toLocaleString()}`);
-			console.log(`<font color='#00FFFF'>[ShardCoordinator]</font>   CPU: ${cpu.toFixed(1)}, Bucket: ${bucket}, Data age: ${age} ticks`);
+			console.log(`[ShardCoordinator] ${shardName}${current}:`);
+			console.log(`[ShardCoordinator]   Colonies: ${colonies}, Energy: ${energy.toLocaleString()}`);
+			console.log(`[ShardCoordinator]   CPU: ${cpu.toFixed(1)}, Bucket: ${bucket}, Data age: ${age} ticks`);
 		});
 
 		// Show operations
@@ -288,9 +288,9 @@ global.ShardCoordinator = {
 		let transfers = _.get(Memory, ["shard", "operations", "creep_transfers"], []);
 		
 		if (colonizations.length > 0 || transfers.length > 0) {
-			console.log(`<font color='#00FFFF'>[ShardCoordinator]</font> === Active Operations ===`);
-			console.log(`<font color='#00FFFF'>[ShardCoordinator]</font> Colonizations: ${colonizations.length}`);
-			console.log(`<font color='#00FFFF'>[ShardCoordinator]</font> Creep transfers: ${transfers.length}`);
+			console.log(`[ShardCoordinator] === Active Operations ===`);
+			console.log(`[ShardCoordinator] Colonizations: ${colonizations.length}`);
+			console.log(`[ShardCoordinator] Creep transfers: ${transfers.length}`);
 		}
 	}
 };

--- a/definitions_sites.js
+++ b/definitions_sites.js
@@ -2601,14 +2601,31 @@
 				listRoute = _.get(Memory, ["sites", "colonization", rmTarget, "list_route"]);
 				const rmTargetBase = _.isString(rmTarget) && rmTarget.indexOf("/") >= 0 ? rmTarget.split("/")[1] : rmTarget;
 				
-				// Check if target room is already colonized with spawns - if so, clean up the mission
+				// Check local visibility first
 				const targetRoom = Game.rooms[rmTargetBase];
 				if (targetRoom && targetRoom.controller && targetRoom.controller.my) {
 					const spawns = targetRoom.find(FIND_MY_SPAWNS);
 					if (spawns.length > 0) {
-						// Room has spawns! Colonization complete, clean up mission
 						delete Memory["sites"]["colonization"][rmTarget];
 						console.log(`<font color="#4ECDC4">[Colonization]</font> ${rmTargetBase} colonization complete (${spawns.length} spawns), mission removed.`);
+						Stats_CPU.End(rmColony, `Colonization-${rmTarget}-init`);
+						return;
+					}
+				}
+
+				// Cross-shard completion check via ISM snapshots
+				if (rmTarget.indexOf("/") >= 0) {
+					const ismRooms = [
+						_.get(Memory, ["hive", "ism", "primary_snapshot", "rooms", rmTargetBase]),
+						_.get(Memory, ["hive", "ism", "follower_snapshot", "rooms", rmTargetBase]),
+						_.get(Memory, ["hive", "ism", "global", "rooms", rmTargetBase])
+					];
+					const remote = _.find(ismRooms, r => !!r);
+					const remoteOwned = _.get(remote, ["controller", "my"], false) || _.get(remote, "controller_my", false) || _.get(remote, "my", false);
+					const remoteSpawns = _.get(remote, "spawn_count", 0) || _.get(remote, ["spawns", "length"], 0);
+					if (remoteOwned && remoteSpawns > 0) {
+						delete Memory["sites"]["colonization"][rmTarget];
+						console.log(`<font color="#4ECDC4">[Colonization]</font> ${rmTarget} colonization complete via ISM (${remoteSpawns} spawns), mission removed.`);
 						Stats_CPU.End(rmColony, `Colonization-${rmTarget}-init`);
 						return;
 					}
@@ -2663,7 +2680,6 @@
 				const target = _.get(popTarget, ["colonizer", "amount"], 0);
 				const hasPending = !!pendingColonizer;
 				const shouldSpawn = actual < target && !pendingColonizer;
-				console.log(`<font color="#FF6B6B">[DEBUG]</font> Colonization runPopulation ${rmTarget}: actual=${actual}, target=${target}, pending=${hasPending}, should_spawn=${shouldSpawn}`);
 				
 				if (_.get(popActual, "colonizer", 0) < _.get(popTarget, ["colonizer", "amount"], 0) && !pendingColonizer) {
 					console.log(`<font color="#4ECDC4">[Colonization]</font> Creating spawn request for colonizer to ${rmTarget} from ${rmColony}`);

--- a/definitions_sites.js
+++ b/definitions_sites.js
@@ -305,17 +305,14 @@
 
 					case "soldier": case "paladin":
 						Creep_Roles.Soldier(creep, false, true);
-			},
+						break;
 
-			runScouts: function (rmColony, listColonyCreeps) {
-				let existing = {};
-				_.each(listColonyCreeps, creep => existing[creep.name] = true);
-
-				let scouts = _.filter(Game.creeps, creep => {
-					return _.get(creep, ["memory", "role"]) == "scout"
-						&& (_.get(creep, ["memory", "colony"]) == rmColony
-							|| _.get(creep, ["memory", "room"]) == rmColony);
-				});
+					case "ranger": case "archer":
+						Creep_Roles.Archer(creep, false, true);
+						break;
+				}
+			});
+		},
 
 				_.each(scouts, creep => {
 					if (!existing[creep.name])

--- a/definitions_sites.js
+++ b/definitions_sites.js
@@ -2600,6 +2600,20 @@
 				Stats_CPU.Start(rmColony, `Colonization-${rmTarget}-init`);
 				listRoute = _.get(Memory, ["sites", "colonization", rmTarget, "list_route"]);
 				const rmTargetBase = _.isString(rmTarget) && rmTarget.indexOf("/") >= 0 ? rmTarget.split("/")[1] : rmTarget;
+				
+				// Check if target room is already colonized with spawns - if so, clean up the mission
+				const targetRoom = Game.rooms[rmTargetBase];
+				if (targetRoom && targetRoom.controller && targetRoom.controller.my) {
+					const spawns = targetRoom.find(FIND_MY_SPAWNS);
+					if (spawns.length > 0) {
+						// Room has spawns! Colonization complete, clean up mission
+						delete Memory["sites"]["colonization"][rmTarget];
+						console.log(`<font color="#4ECDC4">[Colonization]</font> ${rmTargetBase} colonization complete (${spawns.length} spawns), mission removed.`);
+						Stats_CPU.End(rmColony, `Colonization-${rmTarget}-init`);
+						return;
+					}
+				}
+				
 				Stats_CPU.End(rmColony, `Colonization-${rmTarget}-init`);
 
 				Stats_CPU.Start(rmColony, `Colonization-${rmTarget}-listCreeps`);
@@ -2619,13 +2633,10 @@
 				});
 				Stats_CPU.End(rmColony, `Colonization-${rmTarget}-listCreeps`);
 
-				if (isPulse_Spawn()) {
-					Stats_CPU.Start(rmColony, `Colonization-${rmTarget}-runPopulation`);
-					this.runPopulation(rmColony, rmTarget, listCreeps, listRoute);
-					Stats_CPU.End(rmColony, `Colonization-${rmTarget}-runPopulation`);
-				}
-
-				Stats_CPU.Start(rmColony, `Colonization-${rmTarget}-runCreeps`);
+			// Run population management every tick to ensure colonizers spawn promptly
+			Stats_CPU.Start(rmColony, `Colonization-${rmTarget}-runPopulation`);
+			this.runPopulation(rmColony, rmTarget, listCreeps, listRoute);
+			Stats_CPU.End(rmColony, `Colonization-${rmTarget}-runPopulation`);
 				this.runCreeps(rmColony, rmTarget, listCreeps, listRoute);
 				Stats_CPU.End(rmColony, `Colonization-${rmTarget}-runCreeps`);
 			},
@@ -2648,7 +2659,14 @@
 					_.sum(popActual));
 
 				const pendingColonizer = _.find(_.get(Memory, ["hive", "spawn_requests"], []), r => r && r.role === "colonizer" && _.get(r, ["args", "target_key"]) === rmTarget);
+				const actual = _.get(popActual, "colonizer", 0);
+				const target = _.get(popTarget, ["colonizer", "amount"], 0);
+				const hasPending = !!pendingColonizer;
+				const shouldSpawn = actual < target && !pendingColonizer;
+				console.log(`<font color="#FF6B6B">[DEBUG]</font> Colonization runPopulation ${rmTarget}: actual=${actual}, target=${target}, pending=${hasPending}, should_spawn=${shouldSpawn}`);
+				
 				if (_.get(popActual, "colonizer", 0) < _.get(popTarget, ["colonizer", "amount"], 0) && !pendingColonizer) {
+					console.log(`<font color="#4ECDC4">[Colonization]</font> Creating spawn request for colonizer to ${rmTarget} from ${rmColony}`);
 					Memory["hive"]["spawn_requests"].push({
 						room: rmColony,
 						listRooms: listSpawnRooms,

--- a/definitions_sites.js
+++ b/definitions_sites.js
@@ -314,12 +314,15 @@
 			});
 		},
 
-				_.each(scouts, creep => {
-					if (!existing[creep.name])
-						Creep_Roles.Scout(creep);
-				});
-			},
+		runScouts: function (rmColony, listColonyCreeps) {
+			let existing = {};
+			_.each(listColonyCreeps, creep => existing[creep.name] = true);
 
+			let scouts = _.filter(Game.creeps, creep => {
+				return _.get(creep, ["memory", "role"]) == "scout"
+					&& (_.get(creep, ["memory", "colony"]) == rmColony
+						|| _.get(creep, ["memory", "room"]) == rmColony);
+			});
 
 			runTowers: function (rmColony) {
 				let is_safe = (_.get(Memory, ["rooms", rmColony, "defense", "hostiles"], new Array()).length == 0);

--- a/definitions_sites.js
+++ b/definitions_sites.js
@@ -117,7 +117,7 @@
 				for (let i = 0; i < structures.length; i++) {
 					if (structures[i].pos.findInRange(threats, 3).length > 0) {
 						if (room.controller.activateSafeMode() == OK)
-							console.log(`<font color=\"#FF0000\">[Invasion]</font> Safe mode activated in ${rmColony}; enemy detected at key base structure!`);
+							console.log(`[Invasion] Safe mode activated in ${rmColony}; enemy detected at key base structure!`);
 						return;
 					}
 				}
@@ -126,7 +126,7 @@
 					for (let i = 0; i < listCreeps.length; i++) {
 						if (listCreeps[i].pos.findInRange(threats, 3).length > 0) {
 							if (room.controller.activateSafeMode() == OK)
-								console.log(`<font color=\"#FF0000\">[Invasion]</font> Safe mode activated in ${rmColony}; no structures; enemy detected at creeps!`);
+								console.log(`[Invasion] Safe mode activated in ${rmColony}; no structures; enemy detected at creeps!`);
 							return;
 						}
 					}
@@ -392,7 +392,7 @@
 					//Ensure we have a spawn, otherwise return 25, 25
 					if(!originX || !originY)
 					{
-						console.log(`<font color=\"#FF0000\">[Invasion]</font> Could not detect any spawns in room ${rmColony}`);
+						console.log(`[Invasion] Could not detect any spawns in room ${rmColony}`);
 						originX = 25;
 						originY = 25;
 					}
@@ -534,7 +534,7 @@
 					});
 
 					Memory["rooms"][rmColony]["links"] = link_defs;
-					console.log(`<font color=\"#D3FFA3\">[Console]</font> Links defined for ${rmColony}.`);
+					console.log(`[Console] Links defined for ${rmColony}.`);
 				}
 
 			},
@@ -1047,7 +1047,7 @@
 					if (source.pos.findInRange(containers, 1).length < 1) {
 						let adj = source.pos.getBuildableTile_Adjacent();
 						if (adj != null && adj.createConstructionSite("container") == OK)
-							console.log(`<font color=\"#6065FF\">[Mining]</font> ${room.name} placing container at (${adj.x}, ${adj.y})`);
+							console.log(`[Mining] ${room.name} placing container at (${adj.x}, ${adj.y})`);
 					}
 				});
 			}
@@ -1191,7 +1191,7 @@
 					return s.structureType == "lab"
 						&& _.filter(labDefinitions, def => { return _.get(def, "action") == "boost" && _.get(def, "lab") == s.id; }).length == 0
 				}).length < 3) {
-					console.log(`<font color=\"#A17BFF\">[Labs]</font> Unable to assign a reaction to ${rmColony}- not enough labs available for reactions (labs boosting?).`);
+					console.log(`[Labs] Unable to assign a reaction to ${rmColony}- not enough labs available for reactions (labs boosting?).`);
 					return;
 				}
 
@@ -1200,7 +1200,7 @@
 						let amount = 0, r1_amount = 0, r2_amount = 0;
 						let reagents = getReagents(_.get(t, "mineral"));
 						if (reagents == null || reagents.length < 2) {
-							console.log(`<font color="#A17BFF">[Labs]</font> Skipping reaction target ${_.get(t, "mineral")} - no reagent mapping found.`);
+							console.log(`[Labs] Skipping reaction target ${_.get(t, "mineral")} - no reagent mapping found.`);
 							return false;
 						}
 						_.each(_.filter(Game.rooms,
@@ -1218,10 +1218,10 @@
 
 				if (target != null) {
 					_.set(Memory, ["resources", "labs", "reactions", rmColony], { mineral: target.mineral, amount: target.amount });
-					console.log(`<font color=\"#A17BFF\">[Labs]</font> Assigning ${rmColony} to create ${target.mineral}.`);
+					console.log(`[Labs] Assigning ${rmColony} to create ${target.mineral}.`);
 				} else {
 					_.set(Memory, ["resources", "labs", "reactions", rmColony], { mineral: null, amount: null });
-					console.log(`<font color=\"#A17BFF\">[Labs]</font> No reaction to assign to ${rmColony}, idling.`);
+					console.log(`[Labs] No reaction to assign to ${rmColony}, idling.`);
 				}
 
 			},
@@ -1305,7 +1305,7 @@
 
 				labDefinitions.push({ action: "reaction", supply1: supply1, supply2: supply2, reactors: reactors });
 				_.set(Memory, ["rooms", rmColony, "labs", "definitions"], labDefinitions);
-				console.log(`<font color=\"#A17BFF\">[Labs]</font> Labs defined for ${rmColony}.`);
+				console.log(`[Labs] Labs defined for ${rmColony}.`);
 			},
 
 			runLabs: function (rmColony) {
@@ -1375,7 +1375,7 @@
 								if (_.get(Memory, ["resources", "labs", "targets", mineral, "is_reagent"]))
 									delete Memory["resources"]["labs"]["targets"][mineral];
 								delete Memory["resources"]["labs"]["reactions"][rmColony];
-								console.log(`<font color=\"#A17BFF\">[Labs]</font> ${rmColony} completed target for ${mineral}, re-assigning lab.`);
+								console.log(`[Labs] ${rmColony} completed target for ${mineral}, re-assigning lab.`);
 								delete Memory["hive"]["pulses"]["lab"];
 								return;
 							}
@@ -1471,7 +1471,7 @@
 
 							lab = Game.getObjectById(listing["supply1"]);
 							if (lab == null) {
-								console.log(`<font color=\"#FF0000\">[Error]</font> Sites.Industry: Game.getObjectById(${listing["supply1"]}) is null.`);
+								console.log(`[Error] Sites.Industry: Game.getObjectById(${listing["supply1"]}) is null.`);
 								return;
 							}
 							else if (lab.mineralType != null && lab.mineralType != supply1_mineral) {
@@ -1487,7 +1487,7 @@
 
 							lab = Game.getObjectById(listing["supply2"]);
 							if (lab == null) {
-								console.log(`<font color=\"#FF0000\">[Error]</font> Sites.Industry: Game.getObjectById(${listing["supply2"]}) is null.`);
+								console.log(`[Error] Sites.Industry: Game.getObjectById(${listing["supply2"]}) is null.`);
 								return;
 							}
 							else if (lab.mineralType != null && lab.mineralType != supply2_mineral) {
@@ -1504,7 +1504,7 @@
 							_.forEach(listing["reactors"], r => {
 								lab = Game.getObjectById(r);
 								if (lab == null) {
-									console.log(`<font color=\"#FF0000\">[Error]</font> Sites.Industry: Game.getObjectById(${r}) is null.`);
+									console.log(`[Error] Sites.Industry: Game.getObjectById(${r}) is null.`);
 									return;
 								}
 								else if (lab.mineralType != null && lab.mineralType != mineral) {
@@ -1559,7 +1559,7 @@
 						if (amount > 0) {
 							// Prevent spamming "new energy order creted" if it's just modifying the amount on an existing order...
 							if (_.get(Memory, ["resources", "terminal_orders", `${rmColony}-energy_critical`]) == null)
-								console.log(`<font color=\"#DC00FF\">[Terminals]</font> Creating critical energy order for ${rmColony} for ${amount} energy.`);
+								console.log(`[Terminals] Creating critical energy order for ${rmColony} for ${amount} energy.`);
 							_.set(Memory, ["resources", "terminal_orders", `${rmColony}-energy_critical`],
 								{ room: rmColony, resource: "energy", amount: amount, automated: true, priority: 1 });
 
@@ -1627,14 +1627,14 @@
 								
 								// Check if this transaction is profitable (we gain more energy than we spend)
 								if (netEnergyGained <= 0) {
-									console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Transaction not profitable: buying ${amountToBuy} energy costs ${energyCost} energy (net gain: ${netEnergyGained}). Skipping.`);
+									console.log(`[Market Emergency] Transaction not profitable: buying ${amountToBuy} energy costs ${energyCost} energy (net gain: ${netEnergyGained}). Skipping.`);
 									return;
 								}
 								
 								// Check if the energy gain is significant enough to make a difference
 								let minSignificantGain = _.get(Memory, ["resources", "market_min_energy_gain"], 1000); // Minimum 1000 net energy gain
 								if (netEnergyGained < minSignificantGain) {
-									console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Energy gain too small: ${netEnergyGained} net energy (minimum: ${minSignificantGain}). Skipping.`);
+									console.log(`[Market Emergency] Energy gain too small: ${netEnergyGained} net energy (minimum: ${minSignificantGain}). Skipping.`);
 									return;
 								}
 								
@@ -1669,7 +1669,7 @@
 										terminal_fuel: true, // Mark as terminal fuel order
 										emergency: true // Mark as emergency to get special handling
 									});
-									console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Terminal in ${rmColony} needs ${energyNeeded} energy for transaction. Creating high-priority energy order.`);
+									console.log(`[Market Emergency] Terminal in ${rmColony} needs ${energyNeeded} energy for transaction. Creating high-priority energy order.`);
 									return; // Wait for terminal to get energy first
 								}
 								
@@ -1686,15 +1686,15 @@
 									net_gain: netEnergyGained
 								});
 
-								console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Creating market buy order: ${amountToBuy} energy at ${bestOrder.price} credits (cost: ${energyCost} energy, net gain: ${netEnergyGained}) to ${bestReceivingRoom} (terminal energy: ${bestRoomEnergy}).`);
+								console.log(`[Market Emergency] Creating market buy order: ${amountToBuy} energy at ${bestOrder.price} credits (cost: ${energyCost} energy, net gain: ${netEnergyGained}) to ${bestReceivingRoom} (terminal energy: ${bestRoomEnergy}).`);
 							} else {
-								console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Energy below threshold but insufficient credits. Need ${totalCost} credits, have ${availableCredits}.`);
+								console.log(`[Market Emergency] Energy below threshold but insufficient credits. Need ${totalCost} credits, have ${availableCredits}.`);
 							}
 						} else {
-							console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Energy below threshold but all available orders are too expensive. Average price: ${avgPrice.toFixed(2)}, max acceptable: ${maxPrice.toFixed(2)}.`);
+							console.log(`[Market Emergency] Energy below threshold but all available orders are too expensive. Average price: ${avgPrice.toFixed(2)}, max acceptable: ${maxPrice.toFixed(2)}.`);
 						}
 					} else {
-						console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Energy below threshold but no energy sell orders available on market.`);
+						console.log(`[Market Emergency] Energy below threshold but no energy sell orders available on market.`);
 					}
 				}
 			},
@@ -1718,7 +1718,7 @@
 
 					if (_.get(order, "active", true) == false) {
 						if (order.emergency) {
-							console.log(`<font color=\"#FFA500\">[Debug]</font> Emergency order ${order.name} skipped - inactive`);
+							console.log(`[Debug] Emergency order ${order.name} skipped - inactive`);
 						}
 						continue;
 					}
@@ -1777,13 +1777,13 @@
 								order["room"] = replacement.roomName;
 								order["resource"] = replacement.resourceType;
 
-								console.log(`<font color=\"#00F0FF\">[Market]</font> Replacement market order found for ${o}!`);
+								console.log(`[Market] Replacement market order found for ${o}!`);
 								return true;
 							} else {
-								console.log(`<font color=\"#00F0FF\">[Market]</font> No replacement market order found for ${o}; order deleted!`);
+								console.log(`[Market] No replacement market order found for ${o}; order deleted!`);
 
 								if (order.emergency) {
-									console.log(`<font color=\"#FFA500\">[Debug]</font> Emergency order ${o} deleted - no replacement found`);
+									console.log(`[Debug] Emergency order ${o} deleted - no replacement found`);
 								}
 								delete Memory["resources"]["terminal_orders"][o];
 								return false;
@@ -1832,7 +1832,7 @@
 								: Game.market.deal(order["market_id"], amount, rmColony);
 
 							if (result == OK) {
-								console.log(`<font color=\"#DC00FF\">[Terminals]</font> ${o}: ${amount} of ${res} sent, ${rmColony}`
+								console.log(`[Terminals] ${o}: ${amount} of ${res} sent, ${rmColony}`
 									+ ` -> ${order["room"]}`);
 
 								Memory["resources"]["terminal_orders"][o]["amount"] -= amount;
@@ -1842,7 +1842,7 @@
 								return true;
 
 							} else {
-								console.log(`<font color=\"#DC00FF\">[Terminals]</font> ${o}: failed to send, `
+								console.log(`[Terminals] ${o}: failed to send, `
 									+ `${amount} of ${res} ${rmColony} -> ${order["room"]} (code: ${result})`);
 							}
 						} else {
@@ -1891,7 +1891,7 @@
 					let result = Game.market.deal(order["market_id"], amount, rmColony);
 
 					if (result == OK) {
-						console.log(`<font color=\"#DC00FF\">[Terminals]</font> ${o}: ${amount} of ${res} received, ${order["room"]}`
+						console.log(`[Terminals] ${o}: ${amount} of ${res} received, ${order["room"]}`
 							+ ` -> ${rmColony} `);
 
 						Memory["resources"]["terminal_orders"][o]["amount"] -= amount;
@@ -1900,7 +1900,7 @@
 
 						return true;
 					} else {
-						console.log(`<font color=\"#DC00FF\">[Terminals]</font> ${o}: failed to receive`
+						console.log(`[Terminals] ${o}: failed to receive`
 							+ ` ${amount} of ${res} ${order["room"]} -> ${rmColony} (code: ${result})`);
 					}
 				} else {
@@ -1911,7 +1911,7 @@
 						let energyNeeded = Math.max(cost + 1000, 5000); // Need cost + buffer
 						_.set(Memory, ["resources", "terminal_orders", `${rmColony}-energy_emergency`], 
 							{ room: rmColony, resource: "energy", amount: energyNeeded, automated: true, priority: 1 });
-						console.log(`<font color=\"#FF6B6B\">[Market Emergency]</font> Creating emergency energy order for terminal in ${rmColony}: ${energyNeeded} energy needed`);
+						console.log(`[Market Emergency] Creating emergency energy order for terminal in ${rmColony}: ${energyNeeded} energy needed`);
 					}
 					
 					if (_.get(storage, ["store", "energy"]) > room.getCriticalEnergy()) {
@@ -2608,7 +2608,7 @@
 					const spawns = targetRoom.find(FIND_MY_SPAWNS);
 					if (spawns.length > 0) {
 						delete Memory["sites"]["colonization"][rmTarget];
-						console.log(`<font color="#4ECDC4">[Colonization]</font> ${rmTargetBase} colonization complete (${spawns.length} spawns), mission removed.`);
+						console.log(`[Colonization] ${rmTargetBase} colonization complete (${spawns.length} spawns), mission removed.`);
 						Stats_CPU.End(rmColony, `Colonization-${rmTarget}-init`);
 						return;
 					}
@@ -2626,7 +2626,7 @@
 					const remoteSpawns = _.get(remote, "spawn_count", 0) || _.get(remote, ["spawns", "length"], 0);
 					if (remoteOwned && remoteSpawns > 0) {
 						delete Memory["sites"]["colonization"][rmTarget];
-						console.log(`<font color="#4ECDC4">[Colonization]</font> ${rmTarget} colonization complete via ISM (${remoteSpawns} spawns), mission removed.`);
+						console.log(`[Colonization] ${rmTarget} colonization complete via ISM (${remoteSpawns} spawns), mission removed.`);
 						Stats_CPU.End(rmColony, `Colonization-${rmTarget}-init`);
 						return;
 					}
@@ -2683,7 +2683,7 @@
 				const shouldSpawn = actual < target && !pendingColonizer;
 				
 				if (_.get(popActual, "colonizer", 0) < _.get(popTarget, ["colonizer", "amount"], 0) && !pendingColonizer) {
-					console.log(`<font color="#4ECDC4">[Colonization]</font> Creating spawn request for colonizer to ${rmTarget} from ${rmColony}`);
+					console.log(`[Colonization] Creating spawn request for colonizer to ${rmTarget} from ${rmColony}`);
 					Memory["hive"]["spawn_requests"].push({
 						room: rmColony,
 						listRooms: listSpawnRooms,
@@ -2894,7 +2894,7 @@
 						if (_.get(combat, ["tactic", "to_occupy"]))
 							this.setOccupation(combat_id, combat, tactic);
 						delete Memory["sites"]["combat"][combat_id];
-						console.log(`<font color=\"#FFA100\">[Combat: ${combat_id}]</font> Combat completed, removing from memory.`);
+						console.log(`[Combat: ${combat_id}] Combat completed, removing from memory.`);
 						return;
 				}
 			},
@@ -2939,7 +2939,7 @@
 						if (_.get(combat, ["tactic", "to_occupy"], false))
 							this.setOccupation(combat_id, combat, tactic);
 						delete Memory["sites"]["combat"][combat_id];
-						console.log(`<font color=\"#FFA100\">[Combat: ${combat_id}]</font> Combat completed, removing from memory.`);
+						console.log(`[Combat: ${combat_id}] Combat completed, removing from memory.`);
 						return;
 				}
 			},
@@ -3026,7 +3026,7 @@
 							let target_room = Game["rooms"][_.get(combat, "target_room")];
 							if (target_room != null && _.filter(target_room.find(FIND_STRUCTURES), s => { return s.structureType == "tower"; }).length == 0) {
 								_.set(Memory, ["sites", "combat", combat_id, "state_combat"], "complete");
-								console.log(`<font color=\"#FFA100\">[Combat: ${combat_id}]</font> No enemy towers detected! Completing tower drain combat.`);
+								console.log(`[Combat: ${combat_id}] No enemy towers detected! Completing tower drain combat.`);
 								return;
 							}
 						}
@@ -3034,7 +3034,7 @@
 
 					case "complete":
 						delete Memory["sites"]["combat"][combat_id];
-						console.log(`<font color=\"#FFA100\">[Combat: ${combat_id}]</font> Combat completed, removing from memory.`);
+						console.log(`[Combat: ${combat_id}] Combat completed, removing from memory.`);
 						return;
 				}
 			},
@@ -3076,7 +3076,7 @@
 						if (_.get(combat, ["tactic", "to_occupy"]))
 							this.setOccupation(combat_id, combat, tactic);
 						delete Memory["sites"]["combat"][combat_id];
-						console.log(`<font color=\"#FFA100\">[Combat: ${combat_id}]</font> Combat completed, removing from memory.`);
+						console.log(`[Combat: ${combat_id}] Combat completed, removing from memory.`);
 						return;
 				}
 			},
@@ -3096,11 +3096,11 @@
 				if (state_combat == "rallying" && listCreeps.length > 0 && Game.time % 5 == 0) {
 					if (creeps_rallied.length == listCreeps.length) {
 						_.set(Memory, ["sites", "combat", combat_id, "state_combat"], "attacking");
-						console.log(`<font color=\"#FFA100\">[Combat: ${combat_id}]</font> All creeps at rally point. Launching attack!`);
+						console.log(`[Combat: ${combat_id}] All creeps at rally point. Launching attack!`);
 						return true;
 					}
 				} else if (Game.time % 50 == 0) {
-					console.log(`<font color=\"#FFA100\">[Combat: ${combat_id}]</font> Spawning and rallying troops, `
+					console.log(`[Combat: ${combat_id}] Spawning and rallying troops, `
 						+ `${creeps_rallied.length} of ${army_amount} at rally point.`);
 				}
 				return false;
@@ -3184,7 +3184,7 @@
 			evaluateDefeat_CreepsWiped: function (combat_id, combat, listCreeps) {
 				if (listCreeps.length == 0 && _.get(combat, ["tactic", "spawn_repeat"]) != true) {
 					_.set(Memory, ["sites", "combat", combat_id, "state_combat"], "complete");
-					console.log(`<font color=\"#FFA100\">[Combat: ${combat_id}]</font> Defeat detected by all friendly creeps killed! Stopping attack.`);
+					console.log(`[Combat: ${combat_id}] Defeat detected by all friendly creeps killed! Stopping attack.`);
 					return true;
 				}
 				return false;
@@ -3201,7 +3201,7 @@
 						});
 					if (_.get(combat, ["tactic", "target_structures"]) == true && attack_structures.length == 0) {
 						_.set(Memory, ["sites", "combat", combat_id, "state_combat"], "complete");
-						console.log(`<font color=\"#FFA100\">[Combat: ${combat_id}]</font> Victory detected by destroying all structures! Stopping attack.`);
+						console.log(`[Combat: ${combat_id}] Victory detected by destroying all structures! Stopping attack.`);
 						return true;
 					}
 				}
@@ -3219,7 +3219,7 @@
 
 					if (targets_remaining.length == 0) {
 						_.set(Memory, ["sites", "combat", combat_id, "state_combat"], "complete");
-						console.log(`<font color=\"#FFA100\">[Combat: ${combat_id}]</font> Victory detected by destroying all targets on target list! Stopping attack.`);
+						console.log(`[Combat: ${combat_id}] Victory detected by destroying all targets on target list! Stopping attack.`);
 						return true;
 					}
 				}
@@ -3236,7 +3236,7 @@
 			},
 
 			setOccupation: function (combat_id, combat, tactic) {
-				console.log(`<font color=\"#FFA100\">[Combat: ${combat_id}]</font> `
+				console.log(`[Combat: ${combat_id}] `
 					+ `Setting occupation request in Memory; combat_id ${combat_id}-occupy.`);
 				_.set(Memory, ["sites", "combat", `${combat_id}-occupy`],
 					{
@@ -3269,9 +3269,9 @@
 			
 			// Debug: Log highway mining status
 			if (Game.time % 50 == 0) {
-				console.log(`<font color=\"#FFA500\">[Highway Debug]</font> Highway ${highway_id}: ${listCreeps.length} creeps, state: ${highwayData.state}`);
+				console.log(`[Highway Debug] Highway ${highway_id}: ${listCreeps.length} creeps, state: ${highwayData.state}`);
 				_.each(listCreeps, c => {
-					console.log(`<font color=\"#FFA500\">[Highway Debug]</font> - ${c.name}: ${c.memory.role} in ${c.room.name}`);
+					console.log(`[Highway Debug] - ${c.name}: ${c.memory.role} in ${c.room.name}`);
 				});
 			}
 			
@@ -3346,7 +3346,7 @@
 						if (!highwayData.replacement_queued || Game.time - (highwayData.last_replacement || 0) > travel_time) {
 							highwayData.replacement_queued = true;
 							highwayData.last_replacement = Game.time;
-							console.log(`<font color=\"#FFA500\">[Highway]</font> Queuing replacement burrower for ${highway_id} (${replacementReason})`);
+							console.log(`[Highway] Queuing replacement burrower for ${highway_id} (${replacementReason})`);
 							Memory["shard"]["spawn_requests"].push({
 								room: highwayData.colony, listRooms: listSpawnRooms,
 								priority: 15,
@@ -3364,7 +3364,7 @@
 					// Clear replacement flag when new burrower arrives (fresh spawn)
 					if (burrower.ticksToLive > 1500) { // Fresh spawn
 						highwayData.replacement_queued = false;
-						console.log(`<font color=\"#FFA500\">[Highway]</font> New burrower arrived, clearing replacement flag for ${highway_id}`);
+						console.log(`[Highway] New burrower arrived, clearing replacement flag for ${highway_id}`);
 					}
 				}
 
@@ -3430,7 +3430,7 @@
 							}
 						});
 										if (role === "highway_burrower") {
-					console.log(`<font color=\"#FFA500\">[Highway]</font> Spawning single extractor (level 8: 25 WORK, 8 CARRY, 17 MOVE) for commodity mining in ${highway_id}`);
+					console.log(`[Highway] Spawning single extractor (level 8: 25 WORK, 8 CARRY, 17 MOVE) for commodity mining in ${highway_id}`);
 				}
 					}
 				});
@@ -3482,7 +3482,7 @@
 				let activeCreeps = _.filter(Game.creeps, c => c.memory.highway_id === highway_id && !c.spawning);
 				if (activeCreeps.length === 0) {
 					// No active creeps, but don't mark as completed yet - wait for spawn
-					console.log(`<font color=\"#FFA500\">[Highway]</font> No active creeps for ${highway_id}, waiting for spawn`);
+					console.log(`[Highway] No active creeps for ${highway_id}, waiting for spawn`);
 					return;
 				}
 				
@@ -3491,7 +3491,7 @@
 				if (!resource) {
 					// Resource no longer exists, mark as completed
 					highwayData.state = "completed";
-					console.log(`<font color=\"#FFA500\">[Highway]</font> Resource ${resourceId} no longer exists, marking operation as completed for ${highway_id}`);
+					console.log(`[Highway] Resource ${resourceId} no longer exists, marking operation as completed for ${highway_id}`);
 					return;
 				}
 				
@@ -3499,7 +3499,7 @@
 				if (resourceType == 'power' && resource.structureType == STRUCTURE_POWER_BANK) {
 					if (resource.hits <= 0) {
 						highwayData.state = "completed";
-						console.log(`<font color=\"#FFA500\">[Highway]</font> Power bank ${resourceId} depleted, marking operation as completed for ${highway_id}`);
+						console.log(`[Highway] Power bank ${resourceId} depleted, marking operation as completed for ${highway_id}`);
 						return;
 					}
 				}
@@ -3508,7 +3508,7 @@
 				if (resourceType != 'power' && resource.structureType == "deposit") {
 					if (resource.ticksToDeposit <= 0) {
 						highwayData.state = "completed";
-						console.log(`<font color=\"#FFA500\">[Highway]</font> Deposit ${resourceId} depleted, marking operation as completed for ${highway_id}`);
+						console.log(`[Highway] Deposit ${resourceId} depleted, marking operation as completed for ${highway_id}`);
 						return;
 					}
 				}
@@ -3518,7 +3518,7 @@
 				let timeElapsed = Game.time - operationStart;
 				if (timeElapsed > 5000 && activeCreeps.length === 0) { // Much longer timeout, only if no creeps
 					highwayData.state = "completed";
-					console.log(`<font color=\"#FFA500\">[Highway]</font> Operation timeout after ${timeElapsed} ticks with no active creeps, marking as completed for ${highway_id}`);
+					console.log(`[Highway] Operation timeout after ${timeElapsed} ticks with no active creeps, marking as completed for ${highway_id}`);
 					return;
 				}
 			},
@@ -3655,7 +3655,7 @@
 				
 				// Return if any condition is met
 				if (shouldReturn) {
-					console.log(`<font color=\"#FFA500\">[Highway]</font> Burrower ${creep.name} returning home (${returnReason}) from ${creep.room.name} with ${carrySum}/${creep.carryCapacity} resources`);
+					console.log(`[Highway] Burrower ${creep.name} returning home (${returnReason}) from ${creep.room.name} with ${carrySum}/${creep.carryCapacity} resources`);
 					creep.memory.state = "returning";
 					creep.memory.task = creep.getTask_Highway_Carry_Resource();
 					creep.runTask(creep);
@@ -3672,7 +3672,7 @@
 					if (droppedResources.length > 0) {
 						let closestDrop = creep.pos.findClosestByPath(droppedResources);
 						if (closestDrop) {
-							console.log(`<font color=\"#FFA500\">[Highway]</font> Empty burrower ${creep.name} picking up dropped ${highwayData.resource_type}`);
+							console.log(`[Highway] Empty burrower ${creep.name} picking up dropped ${highwayData.resource_type}`);
 							creep.memory.task = {
 								type: "pickup",
 								id: closestDrop.id,
@@ -3697,7 +3697,7 @@
 					if (droppedResources.length > 0 && _.sum(creep.carry) < creep.carryCapacity) {
 						let closestDrop = creep.pos.findClosestByPath(droppedResources);
 						if (closestDrop) {
-							console.log(`<font color=\"#FFA500\">[Highway]</font> Returning burrower ${creep.name} picking up dropped ${highwayData.resource_type}`);
+							console.log(`[Highway] Returning burrower ${creep.name} picking up dropped ${highwayData.resource_type}`);
 							creep.memory.task = {
 								type: "pickup",
 								id: closestDrop.id,
@@ -3724,7 +3724,7 @@
 					if (droppedResources.length > 0 && _.sum(creep.carry) < creep.carryCapacity) {
 						let closestDrop = creep.pos.findClosestByPath(droppedResources);
 						if (closestDrop) {
-							console.log(`<font color=\"#FFA500\">[Highway]</font> Burrower ${creep.name} picking up dropped ${highwayData.resource_type}`);
+							console.log(`[Highway] Burrower ${creep.name} picking up dropped ${highwayData.resource_type}`);
 							creep.memory.task = {
 								type: "pickup",
 								id: closestDrop.id,

--- a/definitions_sites.js
+++ b/definitions_sites.js
@@ -297,13 +297,7 @@
 
 					switch (_.get(creep, ["memory", "role"])) {
 						case "scout": Creep_Roles.Scout(creep); break;
-						case "worker": Creep_Roles.Worker(creep); break;
-						case "upgrader": Creep_Roles.Upgrader(creep, _.get(Memory, ["rooms", rmColony, "defense", "is_safe"], true)); break;
-						case "healer": Creep_Roles.Healer(creep, true); break;
-						case "portal_scout": Creep_Roles.Portal_Scout(creep); break;
-
-						case "soldier": case "paladin":
-							Creep_Roles.Soldier(creep, false, true);
+					case "miner": Creep_Roles.Mining(creep, _.get(Memory, ["rooms", rmColony, "defense", "is_safe"], true)); break;
 							break;
 
 						case "ranger": case "archer":

--- a/definitions_sites.js
+++ b/definitions_sites.js
@@ -2670,7 +2670,7 @@
 					Memory["hive"]["spawn_requests"].push({
 						room: rmColony,
 						listRooms: listSpawnRooms,
-						priority: 21,
+						priority: 5,
 						level: _.get(popTarget, ["colonizer", "level"], colonyLevel),
 						scale: _.get(popTarget, ["colonizer", "scale"], false),
 						body: _.get(popTarget, ["colonizer", "body"], "reserver_at"),

--- a/definitions_sites.js
+++ b/definitions_sites.js
@@ -324,8 +324,15 @@
 						|| _.get(creep, ["memory", "room"]) == rmColony);
 			});
 
-			runTowers: function (rmColony) {
-				let is_safe = (_.get(Memory, ["rooms", rmColony, "defense", "hostiles"], new Array()).length == 0);
+			_.each(scouts, creep => {
+				if (!existing[creep.name])
+					Creep_Roles.Scout(creep);
+			});
+		},
+
+
+		runTowers: function (rmColony) {
+			let is_safe = (_.get(Memory, ["rooms", rmColony, "defense", "hostiles"], new Array()).length == 0);
 
 				if (!is_safe) {
 					_.set(Memory, ["rooms", rmColony, "defense", "targets", "heal"], null);

--- a/definitions_sites.js
+++ b/definitions_sites.js
@@ -298,13 +298,13 @@
 					switch (_.get(creep, ["memory", "role"])) {
 						case "scout": Creep_Roles.Scout(creep); break;
 					case "miner": Creep_Roles.Mining(creep, _.get(Memory, ["rooms", rmColony, "defense", "is_safe"], true)); break;
-							break;
+					case "worker": Creep_Roles.Worker(creep); break;
+					case "upgrader": Creep_Roles.Upgrader(creep, _.get(Memory, ["rooms", rmColony, "defense", "is_safe"], true)); break;
+					case "healer": Creep_Roles.Healer(creep, true); break;
+					case "portal_scout": Creep_Roles.Portal_Scout(creep); break;
 
-						case "ranger": case "archer":
-							Creep_Roles.Archer(creep, false, true);
-							break;
-					}
-				});
+					case "soldier": case "paladin":
+						Creep_Roles.Soldier(creep, false, true);
 			},
 
 			runScouts: function (rmColony, listColonyCreeps) {

--- a/definitions_visual_elements.js
+++ b/definitions_visual_elements.js
@@ -55,7 +55,7 @@
 			// Use cached data for shard visuals
 			if (Game.shard) {
 				if (_.get(Memory, ["hive", "visuals", "show_shard_health"], true) == true) {
-					this.Show_Shard_Health_Cached();
+					this.Show_Shard_Health();
 				}
 				if (_.get(Memory, ["hive", "visuals", "show_portal_indicators"], true) == true) {
 					this.Show_Portal_Indicators();

--- a/overloads_creep_tasks.js
+++ b/overloads_creep_tasks.js
@@ -88,7 +88,7 @@
 					let highwayData = _.get(Memory, ["sites", "highway_mining", this.memory.highway_id]);
 					if (highwayData) {
 						highwayData.state = "completed";
-						console.log(`<font color=\"#FFA500\">[Highway]</font> Deposit ${obj.id} depleted during harvest, marking operation as completed for ${this.memory.highway_id}`);
+						console.log(`[Highway] Deposit ${obj.id} depleted during harvest, marking operation as completed for ${this.memory.highway_id}`);
 					}
 					delete this.memory.task;
 					return;
@@ -1290,11 +1290,11 @@ Creep.prototype.getTask_Highway_Attack_Power = function getTask_Highway_Attack_P
 		if (target) {
 			highwayData.resource_id = target.id;
 			highwayData.last_discovery = Game.time;
-			console.log(`<font color=\"#FFA500\">[Highway]</font> Attacker ${this.name} discovered power bank ${target.id} in ${this.room.name}`);
+			console.log(`[Highway] Attacker ${this.name} discovered power bank ${target.id} in ${this.room.name}`);
 		} else {
 			// No power banks found, mark as completed
 			highwayData.state = "completed";
-			console.log(`<font color=\"#FFA500\">[Highway]</font> No power banks found in ${this.room.name}, marking operation as completed for ${highwayId}`);
+			console.log(`[Highway] No power banks found in ${this.room.name}, marking operation as completed for ${highwayId}`);
 			return;
 		}
 	}
@@ -1302,7 +1302,7 @@ Creep.prototype.getTask_Highway_Attack_Power = function getTask_Highway_Attack_P
 	// Check if power bank is depleted
 	if (target.hits <= 0) {
 		highwayData.state = "completed";
-		console.log(`<font color=\"#FFA500\">[Highway]</font> Power bank ${target.id} depleted, marking operation as completed for ${highwayId}`);
+		console.log(`[Highway] Power bank ${target.id} depleted, marking operation as completed for ${highwayId}`);
 		return;
 	}
 
@@ -1339,16 +1339,16 @@ Creep.prototype.getTask_Highway_Harvest_Commodity = function getTask_Highway_Har
 			if (deposit) {
 				highwayData.resource_id = deposit.id;
 				highwayData.last_discovery = Game.time;
-				console.log(`<font color=\"#FFA500\">[Highway]</font> Burrower ${this.name} discovered deposit ${deposit.id} (${deposit.depositType}) in ${this.room.name}`);
+				console.log(`[Highway] Burrower ${this.name} discovered deposit ${deposit.id} (${deposit.depositType}) in ${this.room.name}`);
 				return this.getTask_Wait(1);
 			} else {
 				// Check if we should mark as completed due to no valid deposits
 				if (this.shouldMarkCompleted(highwayData)) {
 					highwayData.state = "completed";
-					console.log(`<font color=\"#FFA500\">[Highway]</font> No valid deposits found in ${this.room.name}, marking operation as completed for ${highwayId}`);
+					console.log(`[Highway] No valid deposits found in ${this.room.name}, marking operation as completed for ${highwayId}`);
 					return;
 				}
-				console.log(`<font color=\"#FFA500\">[Highway]</font> Burrower ${this.name} could not find deposit of type ${highwayData.resource_type} in ${this.room.name}, waiting.`);
+				console.log(`[Highway] Burrower ${this.name} could not find deposit of type ${highwayData.resource_type} in ${this.room.name}, waiting.`);
 				return { type: "wait", ticks: 10 };
 			}
 		} else {
@@ -1362,9 +1362,9 @@ Creep.prototype.getTask_Highway_Harvest_Commodity = function getTask_Highway_Har
 		// Enhanced completion logic
 		if (this.shouldMarkCompleted(highwayData)) {
 			highwayData.state = "completed";
-			console.log(`<font color=\"#FFA500\">[Highway]</font> Resource ${targetId} invalid or gone, marking operation as completed for ${highwayId}`);
+			console.log(`[Highway] Resource ${targetId} invalid or gone, marking operation as completed for ${highwayId}`);
 		} else {
-			console.log(`<font color=\"#FFA500\">[Highway]</font> Resource ${targetId} invalid or gone, but operation continues for ${highwayId}`);
+			console.log(`[Highway] Resource ${targetId} invalid or gone, but operation continues for ${highwayId}`);
 		}
 		return;
 	}
@@ -1372,13 +1372,13 @@ Creep.prototype.getTask_Highway_Harvest_Commodity = function getTask_Highway_Har
 	// Check if deposit is depleted
 	if (target.ticksToDeposit <= 0) {
 		highwayData.state = "completed";
-		console.log(`<font color=\"#FFA500\">[Highway]</font> Deposit ${targetId} depleted, marking operation as completed for ${highwayId}`);
+		console.log(`[Highway] Deposit ${targetId} depleted, marking operation as completed for ${highwayId}`);
 		return;
 	}
 
 	// Handle deposit cooldown
 	if (target.cooldown > 0) {
-		console.log(`<font color=\"#FFA500\">[Highway]</font> Deposit in cooldown (${target.cooldown} ticks), waiting`);
+		console.log(`[Highway] Deposit in cooldown (${target.cooldown} ticks), waiting`);
 		return this.getTask_Wait(target.cooldown);
 	}
 
@@ -1388,7 +1388,7 @@ Creep.prototype.getTask_Highway_Harvest_Commodity = function getTask_Highway_Har
 		let path = this.pos.findPathTo(new RoomPosition(25, 25, highwayData.colony), { ignoreCreeps: true });
 		if (path && path.length > 0) {
 			highwayData.travel_time = path.length;
-			console.log(`<font color=\"#FFA500\">[Highway]</font> Travel time from deposit to colony: ${path.length} ticks`);
+			console.log(`[Highway] Travel time from deposit to colony: ${path.length} ticks`);
 		}
 	}
 
@@ -1441,15 +1441,15 @@ Creep.prototype.shouldRediscoverResource = function(highwayData) {
 Creep.prototype.findValidDeposit = function(resourceType) {
     let deposits = this.room.find(FIND_DEPOSITS);
     if (deposits.length === 0) {
-        console.log(`<font color=\"#FFA500\">[Highway]</font> No deposits found in ${this.room.name}`);
+        console.log(`[Highway] No deposits found in ${this.room.name}`);
     } else {
         deposits.forEach(d => {
-            console.log(`<font color=\"#FFA500\">[Highway]</font> Deposit ${d.id} type: ${d.depositType}, ticksToDecay: ${d.ticksToDecay}, cooldown: ${d.cooldown}`);
+            console.log(`[Highway] Deposit ${d.id} type: ${d.depositType}, ticksToDecay: ${d.ticksToDecay}, cooldown: ${d.cooldown}`);
         });
     }
     let found = _.find(deposits, d => d.depositType === resourceType && d.ticksToDecay > 0);
     if (!found) {
-        console.log(`<font color=\"#FFA500\">[Highway]</font> No deposit of type ${resourceType} found in ${this.room.name}`);
+        console.log(`[Highway] No deposit of type ${resourceType} found in ${this.room.name}`);
     }
     return found;
 };
@@ -1461,13 +1461,13 @@ Creep.prototype.findValidPowerBank = function() {
     });
     
     if (powerBanks.length === 0) {
-        console.log(`<font color=\"#FFA500\">[Highway]</font> No power banks found in ${this.room.name}`);
+        console.log(`[Highway] No power banks found in ${this.room.name}`);
         return null;
     }
     
     // Return the power bank with the most hits (most valuable)
     let bestPowerBank = _.max(powerBanks, p => p.hits);
-    console.log(`<font color=\"#FFA500\">[Highway]</font> Found power bank ${bestPowerBank.id} with ${bestPowerBank.hits} hits in ${this.room.name}`);
+    console.log(`[Highway] Found power bank ${bestPowerBank.id} with ${bestPowerBank.hits} hits in ${this.room.name}`);
     return bestPowerBank;
 };
 
@@ -1498,14 +1498,14 @@ Creep.prototype.getTask_Highway_Carry_Resource = function getTask_Highway_Carry_
 
 	// If we have resources, return to colony 
 	if (_.sum(this.carry) > 0) {
-		console.log(`<font color=\"#FFA500\">[Highway]</font> Highway burrower ${this.name} carrying ${_.sum(this.carry)} resources, traveling to colony`);
+		console.log(`[Highway] Highway burrower ${this.name} carrying ${_.sum(this.carry)} resources, traveling to colony`);
 		
 		// Try to find storage first, then terminal
 		let storage = Game.rooms[highwayData.colony] && Game.rooms[highwayData.colony].storage;
 		let terminal = Game.rooms[highwayData.colony] && Game.rooms[highwayData.colony].terminal;
 		
 		if (storage && this.room.name === storage.pos.roomName && this.pos.isNearTo(storage)) {
-			console.log(`<font color=\"#FFA500\">[Highway]</font> Highway burrower ${this.name} is adjacent to storage, depositing`);
+			console.log(`[Highway] Highway burrower ${this.name} is adjacent to storage, depositing`);
 			return {
 				type: "deposit",
 				resource: highwayData.resource_type,
@@ -1513,7 +1513,7 @@ Creep.prototype.getTask_Highway_Carry_Resource = function getTask_Highway_Carry_
 				timer: 60
 			};
 		} else if (terminal && this.room.name === terminal.pos.roomName && this.pos.isNearTo(terminal)) {
-			console.log(`<font color=\"#FFA500\">[Highway]</font> Highway burrower ${this.name} is adjacent to terminal, depositing`);
+			console.log(`[Highway] Highway burrower ${this.name} is adjacent to terminal, depositing`);
 			return {
 				type: "deposit",
 				resource: highwayData.resource_type,
@@ -1521,14 +1521,14 @@ Creep.prototype.getTask_Highway_Carry_Resource = function getTask_Highway_Carry_
 				timer: 60
 			};
 		} else if (storage) {
-			console.log(`<font color=\"#FFA500\">[Highway]</font> Highway burrower ${this.name} traveling directly to storage`);
+			console.log(`[Highway] Highway burrower ${this.name} traveling directly to storage`);
 			return {
 				type: "travel",
 				destination: storage.pos,
 				timer: 100
 			};
 		} else if (terminal) {
-			console.log(`<font color=\"#FFA500\">[Highway]</font> Highway burrower ${this.name} traveling directly to terminal`);
+			console.log(`[Highway] Highway burrower ${this.name} traveling directly to terminal`);
 			return {
 				type: "travel",
 				destination: terminal.pos,
@@ -1536,7 +1536,7 @@ Creep.prototype.getTask_Highway_Carry_Resource = function getTask_Highway_Carry_
 			};
 		} else {
 			// Fallback to room center if no storage/terminal
-			console.log(`<font color=\"#FFA500\">[Highway]</font> Highway burrower ${this.name} no storage/terminal found, traveling to room center`);
+			console.log(`[Highway] Highway burrower ${this.name} no storage/terminal found, traveling to room center`);
 			return {
 				type: "travel",
 				destination: new RoomPosition(25, 25, highwayData.colony),
@@ -1548,7 +1548,7 @@ Creep.prototype.getTask_Highway_Carry_Resource = function getTask_Highway_Carry_
 	// Find storage or terminal to deposit
 	let storage = this.room.storage;
 	if (storage) {
-		console.log(`<font color=\"#FFA500\">[Highway]</font> Highway burrower ${this.name} depositing to storage`);
+		console.log(`[Highway] Highway burrower ${this.name} depositing to storage`);
 		return {
 			type: "deposit",
 			resource: highwayData.resource_type,
@@ -1558,7 +1558,7 @@ Creep.prototype.getTask_Highway_Carry_Resource = function getTask_Highway_Carry_
 	}
 	let terminal = this.room.terminal;
 	if (terminal) {
-		console.log(`<font color=\"#FFA500\">[Highway]</font> Highway burrower ${this.name} depositing to terminal`);
+		console.log(`[Highway] Highway burrower ${this.name} depositing to terminal`);
 		return {
 			type: "deposit",
 			resource: highwayData.resource_type,
@@ -1568,7 +1568,7 @@ Creep.prototype.getTask_Highway_Carry_Resource = function getTask_Highway_Carry_
 	}
 
 	// No valid deposit location for commodity
-	console.log(`<font color=\"#FFA500\">[Highway]</font> Highway burrower ${this.name} no storage or terminal found for commodity, waiting`);
+	console.log(`[Highway] Highway burrower ${this.name} no storage or terminal found for commodity, waiting`);
 	return {
 		type: "wait",
 		ticks: 10

--- a/overloads_creep_travel.js
+++ b/overloads_creep_travel.js
@@ -381,7 +381,47 @@ Creep.prototype.travelToExitTile = function travelToExitTile(target_name) {
 	for (let i in room_exits) {
 		if (room_exits[i] == target_name) {
 			let exit_tiles = _.get(Memory, ["hive", "paths", "exits", "rooms", this.room.name]);
-			if (exit_tiles == null)
+			
+			// If exit tiles not cached (e.g., on shard1 colonized rooms), generate them on-demand
+			if (exit_tiles == null) {
+				exit_tiles = [];
+				let terrain = new Room.Terrain(this.room.name);
+				
+				// Determine which edges to scan
+				let toScan = [];
+				switch (i) {
+					case '1': toScan = [{x: null, y: 0}]; break;     // Top (y=0)
+					case '3': toScan = [{x: 49, y: null}]; break;    // Right (x=49)
+					case '5': toScan = [{x: null, y: 49}]; break;    // Bottom (y=49)
+					case '7': toScan = [{x: 0, y: null}]; break;     // Left (x=0)
+				}
+				
+				// Scan edge for passable tiles
+				for (let edge of toScan) {
+					if (edge.x !== null) {
+						// Vertical edge (x is fixed)
+						for (let y = 0; y < 50; y++) {
+							if (terrain.get(edge.x, y) !== TERRAIN_MASK_WALL && (y > 0 && y < 49)) {
+								exit_tiles.push({x: edge.x, y: y, roomName: this.room.name});
+							}
+						}
+					} else {
+						// Horizontal edge (y is fixed)
+						for (let x = 0; x < 50; x++) {
+							if (terrain.get(x, edge.y) !== TERRAIN_MASK_WALL && (x > 0 && x < 49)) {
+								exit_tiles.push({x: x, y: edge.y, roomName: this.room.name});
+							}
+						}
+					}
+				}
+				
+				// Cache the result for future use
+				if (exit_tiles.length > 0) {
+					_.set(Memory, ["hive", "paths", "exits", "rooms", this.room.name], exit_tiles);
+				}
+			}
+			
+			if (exit_tiles == null || exit_tiles.length == 0)
 				return ERR_NO_PATH;
 
 			let tile = null;

--- a/overloads_creep_travel.js
+++ b/overloads_creep_travel.js
@@ -575,7 +575,7 @@ Creep.prototype.travelToShard = function(targetShard, targetRoom) {
 		// Transfer already registered, continue to portal
 		let route = Portals.getPortalRoute(this.room.name, targetShard, targetRoom);
 		if (!route) {
-			console.log(`<font color="#FF0000">[Creep]</font> ${this.name}: No portal route to ${targetShard}`);
+			console.log(`[Creep] ${this.name}: No portal route to ${targetShard}`);
 			return ERR_NO_PATH;
 		}
 
@@ -586,7 +586,7 @@ Creep.prototype.travelToShard = function(targetShard, targetRoom) {
 	let route = Portals.getPortalRoute(this.room.name, targetShard, targetRoom);
 	
 	if (!route) {
-		console.log(`<font color="#FF0000">[Creep]</font> ${this.name}: No portal route found to ${targetShard}`);
+		console.log(`[Creep] ${this.name}: No portal route found to ${targetShard}`);
 		return ERR_NO_PATH;
 	}
 
@@ -631,7 +631,7 @@ Creep.prototype.travelToPortal = function(route) {
 				// Move into portal
 				let result = this.moveTo(portalStructure);
 				if (result === OK) {
-					console.log(`<font color="#00FFFF">[Creep]</font> ${this.name} entering portal to ${route.destShard}`);
+					console.log(`[Creep] ${this.name} entering portal to ${route.destShard}`);
 				}
 				return result;
 			} else {
@@ -640,7 +640,7 @@ Creep.prototype.travelToPortal = function(route) {
 			}
 		} else {
 			// Portal not found - may have decayed
-			console.log(`<font color="#FF0000">[Creep]</font> ${this.name}: Portal at ${portal.pos.roomName} not found!`);
+			console.log(`[Creep] ${this.name}: Portal at ${portal.pos.roomName} not found!`);
 			return ERR_NO_PATH;
 		}
 	} else {
@@ -675,7 +675,7 @@ Creep.prototype.cancelShardTransfer = function() {
 	let canceled = beforeLength > Memory.shard.operations.creep_transfers.length;
 	
 	if (canceled) {
-		console.log(`<font color="#FF6600">[Creep]</font> ${this.name}: Canceled shard transfer`);
+		console.log(`[Creep] ${this.name}: Canceled shard transfer`);
 	}
 	
 	return canceled;

--- a/overloads_general.js
+++ b/overloads_general.js
@@ -20,7 +20,7 @@
     getUsername = function () {
         return _.find({...Game.structures, ...Game.creeps, ...Game.constructionSites}).owner.username;
     }
-    
+
     hasCPU = function () {
         return Game.cpu.getUsed() < Game.cpu.limit;
     };


### PR DESCRIPTION
Screeps client no longer renders HTML tags as formatted output - they now display as literal text.

## Changes
- Stripped all HTML formatting (`<font color>`, `</font>`, `<br>`, `<b>`, `<u>`, table tags) from 15 JS files
- `definitions_console_commands.js`: dynamic color indicators replaced with `[OK]`/`[python -m station64.main --tui ../engine/episodes/episode0-backup.yaml]`/`[T]`/`[--]` text equivalents; `join('<br>')` → `join('\n')`
- Removed dead `console.log` override shim from `overloads_general.js` (Screeps VM native bindings cannot be overridden)

## Files changed
- definitions_console_commands.js
- definitions_blueprint.js
- definitions_cpu_profiling.js
- definitions_creep_roles.js
- definitions_global_creeps.js
- definitions_hive_control.js
- definitions_intershard.js
- definitions_intershard_lean.js
- definitions_intershard_memory.js
- definitions_portals.js
- definitions_shard_control.js
- definitions_shard_coordinator.js
- definitions_sites.js
- overloads_creep_tasks.js
- overloads_creep_travel.js
- overloads_general.js

## Verified
- Deployed to game server, no errors on any shard
- `help()` output confirmed clean