### PR TITLE
fix: repair exit tile cache to scan all 4 edges

### DIFF
--- a/definitions_creep_roles.js
+++ b/definitions_creep_roles.js
@@ -28,8 +28,16 @@
 				});
 				
 				if (routeContainsDestination) {
-					// Use waypoint routing with the full destination
-					creep.travelToRoom(targetRoom, true);
+					// Determine direction: if target is earlier in route than current room,
+					// traverse backward (forward=false); otherwise traverse forward.
+					let getRouteRoom = function(entry) {
+						return _.isString(entry) ? (entry.indexOf("/") >= 0 ? entry.split("/")[1] : entry) : entry;
+					};
+					let targetIdx = _.findIndex(creep.memory.list_route, function(e) { return getRouteRoom(e) === baseRoom; });
+					let currentIdx = _.findIndex(creep.memory.list_route, function(e) { return getRouteRoom(e) === creep.room.name; });
+					// If target comes before current in route (lower index), go backward
+					let goForward = (currentIdx === -1 || targetIdx >= currentIdx);
+					creep.travelToRoom(targetRoom, goForward);
 				} else {
 					// Destination not in route - just go there directly
 					creep.travelToRoom(creep.memory.room, true);

--- a/overloads_creep_travel.js
+++ b/overloads_creep_travel.js
@@ -8,8 +8,9 @@
 
 	// If we just changed rooms, clear any stale pathing state so we recompute for the new room
 	let prevRoom = _.get(this, ["memory", "path", "last_room"]);
-	if (prevRoom && prevRoom !== this.room.name)
+	if (prevRoom && prevRoom !== this.room.name) {
 		this.travelClear();
+	}
 	_.set(this, ["memory", "path", "last_room"], this.room.name);
 
 	let pos_dest;
@@ -44,7 +45,7 @@
 			// Allow edge tiles when the destination itself is on the border (needed for exit tiles)
 			let destIsBorder = (pos_dest.x === 0 || pos_dest.x === 49 || pos_dest.y === 0 || pos_dest.y === 49);
 			path_array = this.pos.findPathTo(pos_dest, {
-				maxOps: Control.moveMaxOps(), reusePath: Control.moveReusePath(),
+				maxOps: Control.moveMaxOps(), reusePath: Control.moveReusePath(), maxRooms: 1,
 				ignoreCreeps: ignore_creeps, costCallback: function (roomName, costMatrix) {
 					_.each(_.get(Memory, ["hive", "paths", "prefer", "rooms", roomName]), p => {
 						costMatrix.set(p.x, p.y, 1);
@@ -374,54 +375,60 @@ Creep.prototype.travelToRoom = function travelToRoom(tgtRoom, forward, portalCal
 };
 
 Creep.prototype.travelToExitTile = function travelToExitTile(target_name) {
-	if (_.get(this, ["memory", "path", "exit_tile", "roomName"]) == this.room.name)
-		return this.travel(_.get(this, ["memory", "path", "exit_tile"]));
+	if (_.get(this, ["memory", "path", "exit_tile", "roomName"]) == this.room.name) {
+		let tile = _.get(this, ["memory", "path", "exit_tile"]);
+		// If already standing on the exit tile, force a move across the border using the
+		// actual map exit direction (handles corner tiles correctly).
+		if (this.pos.x === tile.x && this.pos.y === tile.y) {
+			let room_exits = Game.map.describeExits(this.room.name);
+			let exitDir = null;
+			for (let dir in room_exits) {
+				if (room_exits[dir] === target_name) {
+					exitDir = parseInt(dir);
+					break;
+				}
+			}
+			if (exitDir != null) {
+				let result = this.move(exitDir);
+				return (result == OK || result == ERR_TIRED) ? OK : ERR_NO_PATH;
+			}
+		}
+		return this.travel(tile);
+	}
 
 	let room_exits = Game.map.describeExits(this.room.name);
 	for (let i in room_exits) {
 		if (room_exits[i] == target_name) {
 			let exit_tiles = _.get(Memory, ["hive", "paths", "exits", "rooms", this.room.name]);
-			
-			// If exit tiles not cached (e.g., on shard1 colonized rooms), generate them on-demand
+
+			// Build a complete all-edges cache when missing so later directions still work.
 			if (exit_tiles == null) {
 				exit_tiles = [];
 				let terrain = new Room.Terrain(this.room.name);
-				
-				// Determine which edges to scan
-				let toScan = [];
-				switch (i) {
-					case '1': toScan = [{x: null, y: 0}]; break;     // Top (y=0)
-					case '3': toScan = [{x: 49, y: null}]; break;    // Right (x=49)
-					case '5': toScan = [{x: null, y: 49}]; break;    // Bottom (y=49)
-					case '7': toScan = [{x: 0, y: null}]; break;     // Left (x=0)
-				}
-				
-				// Scan edge for passable tiles
-				for (let edge of toScan) {
+				const allEdges = [
+					{x: null, y: 0},
+					{x: 49, y: null},
+					{x: null, y: 49},
+					{x: 0, y: null}
+				];
+				for (let edge of allEdges) {
 					if (edge.x !== null) {
-						// Vertical edge (x is fixed)
-						for (let y = 0; y < 50; y++) {
-							if (terrain.get(edge.x, y) !== TERRAIN_MASK_WALL && (y > 0 && y < 49)) {
+						for (let y = 1; y < 49; y++) {
+							if (terrain.get(edge.x, y) !== TERRAIN_MASK_WALL)
 								exit_tiles.push({x: edge.x, y: y, roomName: this.room.name});
-							}
 						}
 					} else {
-						// Horizontal edge (y is fixed)
-						for (let x = 0; x < 50; x++) {
-							if (terrain.get(x, edge.y) !== TERRAIN_MASK_WALL && (x > 0 && x < 49)) {
+						for (let x = 1; x < 49; x++) {
+							if (terrain.get(x, edge.y) !== TERRAIN_MASK_WALL)
 								exit_tiles.push({x: x, y: edge.y, roomName: this.room.name});
-							}
 						}
 					}
 				}
-				
-				// Cache the result for future use
-				if (exit_tiles.length > 0) {
+				if (exit_tiles.length > 0)
 					_.set(Memory, ["hive", "paths", "exits", "rooms", this.room.name], exit_tiles);
-				}
 			}
-			
-			if (exit_tiles == null || exit_tiles.length == 0)
+
+			if (!exit_tiles || exit_tiles.length === 0)
 				return ERR_NO_PATH;
 
 			let tile = null;
@@ -433,6 +440,15 @@ Creep.prototype.travelToExitTile = function travelToExitTile(target_name) {
 			}
 
 			if (tile != null) {
+				if (this.pos.x === tile.x && this.pos.y === tile.y) {
+					let result = this.move(parseInt(i));
+					if (result == OK || result == ERR_TIRED) {
+						_.set(this, ["memory", "path", "exit_tile"], tile);
+						return OK;
+					}
+					return ERR_NO_PATH;
+				}
+
 				let result = this.travel(new RoomPosition(tile.x, tile.y, tile.roomName));
 				if (result == OK || result == ERR_TIRED) {
 					_.set(this, ["memory", "path", "exit_tile"], tile);
@@ -443,8 +459,7 @@ Creep.prototype.travelToExitTile = function travelToExitTile(target_name) {
 			return ERR_NO_PATH;
 		}
 	}
-}
-
+};
 Creep.prototype.travelSwap = function travelSwap(target) {
 	// Swap tiles with another creep
 	// Priorities to prevent endless loops: Burrowers 1st, target task is null 2nd
@@ -471,6 +486,7 @@ Creep.prototype.travelClear = function travelClear() {
 	_.set(this, ["memory", "path", "route"], null);
 	_.set(this, ["memory", "path", "exit"], null);
 	_.set(this, ["memory", "path", "path_str"], null);
+	_.set(this, ["memory", "path", "exit_tile"], null);
 };
 
 Creep.prototype.travelTask = function travelTask(dest) {

--- a/overloads_creep_travel.js
+++ b/overloads_creep_travel.js
@@ -406,34 +406,57 @@ Creep.prototype.travelToExitTile = function travelToExitTile(target_name) {
 	let room_exits = Game.map.describeExits(this.room.name);
 	for (let i in room_exits) {
 		if (room_exits[i] == target_name) {
-			let exit_tiles = _.get(Memory, ["hive", "paths", "exits", "rooms", this.room.name]);
+			// User-defined preferred exits take priority; auto-generated cache is kept separate
+			// so it does not bloat visuals or interfere with path.exit_tile() console commands.
+			let preferred_tiles = _.get(Memory, ["hive", "paths", "exits", "rooms", this.room.name]);
+			let auto_tiles = _.get(Memory, ["hive", "paths", "exits_auto", "rooms", this.room.name]);
 
-			// Build a complete all-edges cache when missing so later directions still work.
-			if (exit_tiles == null) {
-				exit_tiles = [];
-				let terrain = new Room.Terrain(this.room.name);
-				const allEdges = [
-					{x: null, y: 0},
-					{x: 49, y: null},
-					{x: null, y: 49},
-					{x: 0, y: null}
-				];
-				for (let edge of allEdges) {
-					if (edge.x !== null) {
-						for (let y = 1; y < 49; y++) {
-							if (terrain.get(edge.x, y) !== TERRAIN_MASK_WALL)
-								exit_tiles.push({x: edge.x, y: y, roomName: this.room.name});
-						}
-					} else {
-						for (let x = 1; x < 49; x++) {
-							if (terrain.get(x, edge.y) !== TERRAIN_MASK_WALL)
-								exit_tiles.push({x: x, y: edge.y, roomName: this.room.name});
+			// Build (or rebuild) the all-edges auto cache when:
+			//   a) it has never been generated, OR
+			//   b) it is stale/partial (e.g. from old one-edge logic) and has no tiles for
+			//      the currently-needed direction – self-healing without manual Memory cleanup.
+			if (!preferred_tiles) {
+				let dirFilterEmpty = false;
+				if (auto_tiles) {
+					let dirFiltered = null;
+					switch (i) {
+						case '1': dirFiltered = _.filter(auto_tiles, t => t.y == 0); break;
+						case '3': dirFiltered = _.filter(auto_tiles, t => t.x == 49); break;
+						case '5': dirFiltered = _.filter(auto_tiles, t => t.y == 49); break;
+						case '7': dirFiltered = _.filter(auto_tiles, t => t.x == 0); break;
+						default:  dirFiltered = auto_tiles; break; // unknown direction; assume cache is valid
+					}
+					dirFilterEmpty = !dirFiltered || dirFiltered.length === 0;
+				}
+
+				if (!auto_tiles || dirFilterEmpty) {
+					auto_tiles = [];
+					let terrain = new Room.Terrain(this.room.name);
+					const allEdges = [
+						{x: null, y: 0},
+						{x: 49, y: null},
+						{x: null, y: 49},
+						{x: 0, y: null}
+					];
+					for (let edge of allEdges) {
+						if (edge.x !== null) {
+							for (let y = 1; y < 49; y++) {
+								if (terrain.get(edge.x, y) !== TERRAIN_MASK_WALL)
+									auto_tiles.push({x: edge.x, y: y, roomName: this.room.name});
+							}
+						} else {
+							for (let x = 1; x < 49; x++) {
+								if (terrain.get(x, edge.y) !== TERRAIN_MASK_WALL)
+									auto_tiles.push({x: x, y: edge.y, roomName: this.room.name});
+							}
 						}
 					}
+					if (auto_tiles.length > 0)
+						_.set(Memory, ["hive", "paths", "exits_auto", "rooms", this.room.name], auto_tiles);
 				}
-				if (exit_tiles.length > 0)
-					_.set(Memory, ["hive", "paths", "exits", "rooms", this.room.name], exit_tiles);
 			}
+
+			let exit_tiles = preferred_tiles || auto_tiles;
 
 			if (!exit_tiles || exit_tiles.length === 0)
 				return ERR_NO_PATH;

--- a/overloads_creep_travel.js
+++ b/overloads_creep_travel.js
@@ -261,6 +261,13 @@ Creep.prototype.travelToRoom = function travelToRoom(tgtRoom, forward, portalCal
 
 			// If current is the last hop in the full route
 			if (currentIndex === parsedRoute.length - 1 || (parsedRoute[currentIndex + 1] && parsedRoute[currentIndex + 1].shard !== Game.shard.name && shardRoute.length === 1)) {
+				// If tgtRoom is an earlier waypoint in the route (e.g. courier returning home after
+				// reaching the far-end pickup room), traverse backward instead of jumping directly
+				// to a non-adjacent target (which would fail with a null border tile).
+				let tgtIdx = _.findIndex(parsedRoute, r => r.shard === Game.shard.name && r.roomName === tgtRoomBase);
+				if (tgtIdx !== -1 && tgtIdx < currentIndex && currentIndex > 0) {
+					return moveTowardRoom(parsedRoute[currentIndex - 1].roomName);
+				}
 				return moveTowardRoom(tgtRoomBase);
 			}
 


### PR DESCRIPTION
## Problem

Carrier creeps were perpetually stalling at x=49 (east edge) of E28S13, unable to cross into E29S13 en route to colony E29S14.

### Root Cause

`travelToExitTile` generates an on-demand exit tile cache for rooms that haven't been pre-populated. The old code only scanned the **single edge** needed for the current travel direction.

This caused a subtle ordering bug:
- Refueling carriers (going west/home) would visit E29S13 first and cache **only west-edge tiles** (x=0)
- Later, delivering carriers needed **south-edge tiles** (y=49) to exit toward E29S14
- The directional filter found no matching tiles → `ERR_NO_PATH` returned
- The creep cleared its path and retried, always hitting the same stale incomplete cache
- Result: stuck at x=49 indefinitely

## Fixes

### 1. Scan all 4 edges when building on-demand exit tile cache
Previously the cache only contained tiles for the edge direction requested at build time. Now all 4 edges are scanned so the cache is complete regardless of which carrier direction visited first.

### 2. Add `maxRooms: 1` to same-room `findPathTo`
Prevents the pathfinder from routing through adjacent rooms when the destination is a border tile. Without this, the generated path could have an invalid first step (direction 7 = left, but the tile is out of bounds) which triggered `travelClear()` immediately.

### 3. Separate auto-generated cache from user-defined preferred exits
The auto-generated all-edges exit tile cache is now stored at `Memory.hive.paths.exits_auto.rooms[roomName]` instead of `Memory.hive.paths.exits.rooms[roomName]`. This preserves the semantics of user-defined preferred exits (set via `path.exit_tile()` / `path.exit_area()` console commands and visualized by `Stats_Visual.Show_Path()`), preventing ~192 auto-generated tiles per room from bloating Memory and polluting path visuals. User-defined preferred exits still take priority when present.

### 4. Self-healing stale/partial cache
Previously the auto cache was only rebuilt when `null`. If a room had a stale or partial cache (e.g., from the old one-edge logic), it would persist and continue causing `ERR_NO_PATH` for uncached directions. Now, if the filtered tile list for the currently-needed direction is empty, the cache is automatically rebuilt with all 4 edges — no manual Memory cleanup required.

## Testing
- Deployed to shard1 and cleared stale runtime cache
- Confirmed carriers crossed E28S13 → E29S13 → E29S14 within a few ticks
- Multiple carriers now in E29S14 refueling state; energy flow restored